### PR TITLE
Cycle 2.1 hotfix — BUG-003 + BUG-005

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,7 +5,9 @@ applications:
       phases:
         preBuild:
           commands:
-            - nvm use 18 && npm ci
+            # cycle-2.1 BUG-005 fix: Amplify build image 의 nvm 에 node 18 이 사전 설치 안 됨.
+            # "nvm use 18" 만으로는 "version not installed" 에러. install 먼저 실행.
+            - nvm install 18 && nvm use 18 && npm ci
         build:
           commands:
             - npm run lint:src

--- a/auto_video_create_server/services/account_service.py
+++ b/auto_video_create_server/services/account_service.py
@@ -18,9 +18,20 @@ def authenticate_user(user_id: str, pw: str) -> dict | str | None:
     return None
 
 def get_user_if_active(user_id: str) -> dict | None:
+    """사용자 존재 + 구독 활성 여부 확인.
+
+    cycle-2.1 BUG-003 fix (ADR-6 보강):
+    - ENV=test 환경에서는 구독 만료 체크를 건너뜀 (`check/deduct_credits` 와 일관)
+    - 사용자가 users.json 에 존재하면 만료일 무관 활성으로 간주
+    - test 계정 운영 시 만료 갱신을 PO 가 매번 안 해도 됨
+    """
     users = load_json_from_s3("blog-to-short-form-users", "users.json")
+    is_test_env = os.environ.get("ENV", "").lower() == "test"
     for user in users:
         if user["id"] == user_id:
+            if is_test_env:
+                # cycle-2.1: test 환경은 만료 체크 우회. 존재만 확인.
+                return user
             today = datetime.utcnow().date()
             start = datetime.strptime(user["subscription_start"], "%Y-%m-%d").date()
             end = datetime.strptime(user["subscription_end"], "%Y-%m-%d").date()


### PR DESCRIPTION
## Cycle 2.1 hotfix — BUG-003 + BUG-005

cycle-2 머지 후 C-1 runtime QA 에서 발견된 3개 버그 중 2개 즉시 핫픽스. BUG-004 (OPENAI_API_KEY 무효) 는 PO 가 새 유효 키 발급 시 별도 Lambda env 갱신.

## 🔴 핫픽스 인벤토리

### BUG-005 (Critical) — `feat/cycle-2.1-hotfix` 1번째 커밋 `8c1cb799`
**문제**: Amplify Job #41 빌드 실패 → cycle-2 FE 변경 (헤드라인 / 서브텍스트 / AI 기본 배경 UI / BUG-002 핫픽스) 전체 미배포. 사용자는 2026-04-09 의 ba2c080e (cycle-2 이전) 를 보고 있음.

**원인**: `amplify.yml` 의 `nvm use 18` 만 있고 `nvm install 18` 누락. Amplify build image 의 nvm 에 node 18 사전 미설치.

**수정**: `nvm install 18 && nvm use 18 && npm ci`

### BUG-003 (Critical) — 2번째 커밋 `a41f6400`
**문제**: `get_user_if_active` 에 ENV=test 우회 없음 → test 계정 구독 만료 시 모든 API 차단. C-1 runtime QA 중 발생.

**원인**: ADR-6 (ENV=test 일관 정책) 도입 시 `check_user_credits` / `deduct_credits` 에는 분기 추가했으나 `get_user_if_active` 는 누락.

**수정**: ENV=test 일 때 구독 만료 체크 건너뜀 (존재만 확인). prod 동작 변경 없음.

## 🟡 별도 처리

### BUG-004 (Critical) — Lambda OPENAI_API_KEY 무효
- 워크스페이스 `.env` 와 Lambda env 의 키 hash 동일, 둘 다 401
- 코드/인프라 변경 없음 → **PO 가 새 유효 키 발급 후 `aws lambda update-function-configuration` 로 env 갱신**
- 본 PR 머지 후 별도 처리

## 📦 변경 인벤토리

| 파일 | 변경 | 사유 |
|---|---|---|
| `amplify.yml` | preBuild 에 `nvm install 18 &&` 추가 | BUG-005 |
| `auto_video_create_server/services/account_service.py` | `get_user_if_active` ENV=test bypass | BUG-003 |

## ⚠️ 머지 후 자동 동작

1. `deploy-lambda-test.yml` → test Lambda 자동 배포 (BUG-003 적용)
2. Amplify auto-build (main 브랜치) → cycle-2 FE 전체 배포 (BUG-005 fix 효과로 빌드 성공 예상)
3. `terraform.yml` plan only (auto-apply 비활성화 유지)

## 🧪 머지 후 재검증 필요

- S5 자동 분류 정확도 — BUG-004 키 교체 후 가능
- S1~S3 scripts 생성 — BUG-004 키 교체 후 가능
- S4 DALL-E 실제 경로 — BUG-004 키 교체 후 가능
- FE UI E2E — BUG-005 fix 의 Amplify 빌드 성공 후 가능
- 회원가입 test 계정 만료 우회 — BUG-003 fix 검증

## 산출물

- `agents/outputs/qa/test-run-2026-05-21-runtime.md`
- `agents/outputs/qa/bug-reports/BUG-003-*.md`, `BUG-005-*.md`
- `agents/outputs/qa/release-decision.md` (cycle-2.1 결과 반영 갱신 예정)
