### PR TITLE
cycle-2.2 hotfix — external image host policy (BUG-007 + BUG-008)

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -102,6 +102,19 @@ export default function Home() {
     });
   };
 
+  // cycle-2.2: 외부 이미지가 404/차단 등으로 로드 실패 시 해당 갤러리/슬롯을 hide 한다.
+  // BUG-008 (네이버 OGQ 스티커) 같은 pre-existing + 미래 외부 호스트 변경 대비 안전망.
+  // 시각 회귀로 사용자가 깨진 이미지를 클릭하지 않도록 wrapper 자체 hide.
+  const handleImgError = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    const wrapper = img.closest('li') || img.parentElement;
+    if (wrapper instanceof HTMLElement) {
+      wrapper.style.display = 'none';
+    } else {
+      img.style.display = 'none';
+    }
+  };
+
   // 섹션 미디어 해제 핸들러 (스크립트별 미리보기에서 X 클릭)
   const handleSectionMediaDeselect = (idx: number) => {
     setSectionMedia(prev => {
@@ -428,6 +441,7 @@ export default function Home() {
                                 <img
                                   src={getProxiedImageUrl(section.url as string)}
                                   alt={`스크립트 ${idx + 1} 이미지`}
+                                  onError={handleImgError}
                                   style={{ width: '100%', height: 200, objectFit: 'cover', borderRadius: 8 }}
                                 />
                               ) : (
@@ -501,6 +515,7 @@ export default function Home() {
                                 src={getProxiedImageUrl(url)}
                                 alt=""
                                 loading="lazy"
+                                onError={handleImgError}
                                 style={{ width: '100%', height: 140, objectFit: 'cover', borderRadius: 8, border: selectedIdx !== -1 ? '2px solid #1976d2' : '2px solid transparent' }}
                               />
                               <IconButton
@@ -606,7 +621,8 @@ export default function Home() {
                           src={getProxiedImageUrl(url)}
                           alt=""
                           loading="lazy"
-                          style={{ 
+                          onError={handleImgError}
+                          style={{
                             width: '100%',
                             height: 120,
                             objectFit: 'cover',

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -6,6 +6,7 @@ from services.tts_supertone import tts_with_supertone_multi
 from services.create_creatomate_video import create_creatomate_video, get_creatomate_vars, poll_creatomate_video_url
 from services.account_service import get_user_if_active, check_user_credits, get_current_credits
 from services.ai_background import generate_backgrounds_parallel, FALLBACK_URL as DEFAULT_BG_FALLBACK_URL
+from services.image_mirror import maybe_mirror
 from crawler.dispatcher import UnsupportedPlatformError
 from utils.s3_utils import load_json_from_s3
 import os
@@ -231,7 +232,10 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
         for i, section in enumerate(req.sections, 1):
             zero_idx = i - 1
             if section.type == "image":
-                variables[f"image{i}.source"] = section.url
+                # cycle-2.2 BUG-007: Creatomate 가 차단당하는 외부 호스트(Daum CDN 등) 는
+                # S3 미러링 후 그 URL 을 전달. 그 외 호스트는 원본 그대로.
+                image_src = maybe_mirror(section.url or "", referer="https://brunch.co.kr/")
+                variables[f"image{i}.source"] = image_src
                 variables[f"image{i}.visible"] = "true"
                 variables[f"video{i}.visible"] = "false"
             elif section.type == "video":

--- a/auto_video_create_server/crawler/naver.py
+++ b/auto_video_create_server/crawler/naver.py
@@ -14,9 +14,19 @@ def _normalize_image_url(base_url: str, candidate_url: str) -> str:
 
 
 def _is_valid_naver_image_url(full_url: str) -> bool:
-    """네이버 블로그 이미지 도메인인지 확인한다."""
-    # 모바일/에디터 구조에서 postfiles 외 다양한 pstatic 하위 도메인을 사용한다.
-    return "pstatic.net" in full_url and full_url.startswith(("http://", "https://"))
+    """네이버 블로그 이미지 도메인인지 확인한다.
+
+    cycle-2.2 BUG-008: OGQ 스티커 (`storep-phinf.pstatic.net/ogq_*`) 는 본문 사진이 아니라
+    네이버 이모티콘/스티커. URL 자체가 404 응답하는 경우가 다수 → 갤러리 엑박 / 영상 합성 실패 원인.
+    """
+    if not full_url.startswith(("http://", "https://")):
+        return False
+    if "pstatic.net" not in full_url:
+        return False
+    # OGQ 스티커 제외
+    if "storep-phinf.pstatic.net/ogq_" in full_url:
+        return False
+    return True
 
 
 def _extract_image_candidates(img_tag) -> List[str]:

--- a/auto_video_create_server/services/image_mirror.py
+++ b/auto_video_create_server/services/image_mirror.py
@@ -1,0 +1,116 @@
+"""외부 이미지 → S3 미러링.
+
+cycle-2.2 BUG-007 (브런치 이미지 Daum CDN → Creatomate 403) 대응.
+
+Creatomate 같은 외부 영상 합성 서비스가 일부 이미지 호스트 (Daum CDN 등) 의 이미지를
+fetch 할 때 403 받는 케이스가 있다. 해당 호스트의 이미지는 BE 가 미리 download 해서
+S3 에 미러링한 뒤, Creatomate 에는 S3 URL 을 전달한다.
+
+설계:
+- 차단 위험 있는 호스트 패턴(MIRROR_REQUIRED_PATTERNS) 만 미러링
+- 그 외는 원본 URL 그대로 (Creatomate 가 정상 fetch 하는 호스트는 미러링 비용 0)
+- 캐시: sha256(image_url)[:16].{ext} 키 → 동일 URL 재호출 시 S3 비용 0
+- 미러링 실패 시 원본 URL 반환 (fallback)
+"""
+import hashlib
+import os
+from typing import Optional
+
+import boto3
+import requests
+
+
+BUCKET = "auto-video-tts-files"
+PREFIX = "mirrored-images"
+
+# 차단 위험 있는 호스트 패턴 (cycle-2.2 시점). 신규 패턴 발견 시 여기에 추가.
+MIRROR_REQUIRED_PATTERNS = [
+    "img1.daumcdn.net",  # 브런치 본문 이미지 (BUG-007)
+    "img.daumcdn.net",
+    "t1.daumcdn.net",
+]
+
+
+def needs_mirror(url: str) -> bool:
+    """미러링이 필요한 외부 호스트인지 판별."""
+    if not url:
+        return False
+    return any(p in url for p in MIRROR_REQUIRED_PATTERNS)
+
+
+def _s3_client():
+    return boto3.client(
+        "s3",
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+        region_name="ap-northeast-2",
+    )
+
+
+def _exists_in_s3(s3_key: str) -> bool:
+    try:
+        _s3_client().head_object(Bucket=BUCKET, Key=s3_key)
+        return True
+    except Exception:
+        return False
+
+
+def _guess_ext(url: str) -> str:
+    """URL 의 확장자 추출 (없거나 모호하면 .jpg)."""
+    path = url.split("?")[0].lower()
+    for e in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
+        if path.endswith(e):
+            return e
+    return ".jpg"
+
+
+def _content_type_for(ext: str) -> str:
+    return {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+    }.get(ext, "image/jpeg")
+
+
+def _public_url(s3_key: str) -> str:
+    return f"https://{BUCKET}.s3.ap-northeast-2.amazonaws.com/{s3_key}"
+
+
+def mirror_image_to_s3(image_url: str, referer: Optional[str] = None) -> str:
+    """외부 이미지를 S3 에 미러링하고 공개 URL 반환.
+
+    캐시 적중 시 즉시 반환. miss 시 다운로드 → 업로드 → URL 반환.
+    실패 시 원본 URL 반환 (fallback — 일부 호스트는 Creatomate 가 받을 수도 있음).
+    """
+    ext = _guess_ext(image_url)
+    key_hash = hashlib.sha256(image_url.encode("utf-8")).hexdigest()[:16]
+    s3_key = f"{PREFIX}/{key_hash}{ext}"
+
+    if _exists_in_s3(s3_key):
+        return _public_url(s3_key)
+
+    try:
+        headers = {"User-Agent": "Mozilla/5.0"}
+        if referer:
+            headers["Referer"] = referer
+        resp = requests.get(image_url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        _s3_client().put_object(
+            Bucket=BUCKET,
+            Key=s3_key,
+            Body=resp.content,
+            ContentType=_content_type_for(ext),
+        )
+        return _public_url(s3_key)
+    except Exception as e:
+        print(f"[image_mirror] failed for {image_url[:80]}: {e}")
+        return image_url  # fallback — Creatomate 가 직접 시도해보도록
+
+
+def maybe_mirror(image_url: str, referer: Optional[str] = None) -> str:
+    """필요한 호스트만 미러링, 나머지는 원본 URL 그대로 반환."""
+    if needs_mirror(image_url):
+        return mirror_image_to_s3(image_url, referer=referer)
+    return image_url


### PR DESCRIPTION
## cycle-2.2 hotfix — 외부 이미지 호스트 정책

C-1 runtime QA + C-2 PO QA 에서 발견된 외부 이미지 호스트 관련 두 버그 hotfix.

## 🔴 Bugs

### BUG-007 (Critical) — 브런치 이미지 Daum CDN → Creatomate 403
- 위치: BE generate-video 시점
- 원인: Creatomate 가 `img1.daumcdn.net` 등 Daum CDN 의 이미지를 GET 시 403 받음 → 브런치 변환 영상 실패
- Fix: `services/image_mirror.py` 신규 — 차단 위험 호스트(daumcdn)만 S3 미러링. 그 외(pstatic 등)는 원본 그대로 (비용 최적화). 캐시 적중 시 재호출 비용 0. 실패 시 원본 URL fallback.

### BUG-008 (Medium, pre-existing) — 네이버 OGQ 스티커 404
- 위치: BE 네이버 크롤러
- 원인: 본문 `<img>` 광범위 수집이 OGQ 스티커(`storep-phinf.pstatic.net/ogq_*`) 까지 포함. 해당 URL 패턴이 모두 404 → select step 갤러리 다수 엑박
- Fix: `_is_valid_naver_image_url` 에서 OGQ 패턴 명시적 제외 (1줄)
- 추가: FE `onError` 안전망 — 미래에 다른 호스트가 차단되거나 404 받을 때도 wrapper 자체 hide → 시각 깨짐 방지 + 사용자 클릭 차단

## 📦 변경 인벤토리

| 파일 | 변경 |
|---|---|
| `auto_video_create_server/crawler/naver.py` | `_is_valid_naver_image_url` 에 OGQ 패턴 제외 |
| `auto_video_create_server/services/image_mirror.py` | **신규** — 외부 이미지 S3 미러링 서비스 |
| `auto_video_create_server/api/blog.py` | generate-video 의 image 슬롯에 `maybe_mirror` 적용 |
| `auto_video_create_front/src/app/page.tsx` | `handleImgError` 헬퍼 + 4 개 img 에 `onError` 적용 |

## ✅ 검증

- BE: `python -m py_compile` 통과, unit-style 케이스 모두 expected 와 일치
- FE: `tsc --noEmit` 통과, eslint error 0 (warning 3건은 pre-existing `<img>` next/image 권고)
- 새로 도입된 ci-fe.yml / ci-be.yml 이 PR 에서 자동 실행 → 결과 코멘트로 확인 가능

## 🚀 머지 후 자동 동작

1. `deploy-lambda-test.yml` → test Lambda 자동 배포 (BE 적용)
2. Amplify auto-build (Node 20, AMPLIFY_DIFF_DEPLOY=false) → FE 자동 배포
3. terraform.yml plan only (auto-apply 비활성화 유지)

## 🧪 머지 + 배포 후 — Phase C-2 (PO 직접 test 서버 QA)

비협상 체크리스트:
- 신규 1건: 네이버 비맛집 / 티스토리 / 브런치 1개씩 변환 시도
- 회귀 1건: 기존 맛집 변환 (BUG-008 해결 확인 — 갤러리 엑박 없는지)
- 영상 합성 1건 — 브런치 또는 default 슬롯 (BUG-007 해결 확인)
