### PR TITLE
feat(cycle-3): 자막 스타일(폰트/크기/색) 편집 기능

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ap-northeast-2
       GITHUB_TOKEN: ${{ secrets.AMPLIFY_GITHUB_TOKEN }}
+      # cycle-3: Google Fonts API Key — PO 운영 작업으로 GitHub Secrets 에 GOOGLE_FONTS_API_KEY 등록 필요
+      GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -52,7 +54,7 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -var="github_token=$GITHUB_TOKEN"
+        run: terraform plan -no-color -var="github_token=$GITHUB_TOKEN" -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY"
         working-directory: infra
 
       - name: Add Plan Comment
@@ -73,5 +75,5 @@ jobs:
       # 그동안 인프라 변경이 필요하면 workflow_dispatch 로 plan 만 돌리고 수동 apply.
       - name: Terraform Apply
         if: false  # disabled — see comment above
-        run: terraform apply -auto-approve -var="github_token=$GITHUB_TOKEN"
+        run: terraform apply -auto-approve -var="github_token=$GITHUB_TOKEN" -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY"
         working-directory: infra 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,14 +27,19 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.AMPLIFY_GITHUB_TOKEN }}
       # cycle-3: Google Fonts API Key — PO 운영 작업으로 GitHub Secrets 에 GOOGLE_FONTS_API_KEY 등록 필요
       GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
+      # security-hotfix (cycle-3, 2026-06-01): OPENAI_API_KEY 를 terraform 변수로 관리.
+      # PO 운영 작업: GitHub Secrets 에 OPENAI_API_KEY 등록 필요.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # security-hotfix (cycle-3, 2026-06-01): AWS_SECRET_ACCESS_KEY 평문 echo 제거.
+      # 자격증명 존재 여부만 확인.
       - name: Check AWS env
         run: |
-          echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-          echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+          [ -n "$AWS_ACCESS_KEY_ID" ] && echo "AWS creds: AWS_ACCESS_KEY_ID set" || echo "AWS creds: AWS_ACCESS_KEY_ID NOT set"
+          [ -n "$AWS_SECRET_ACCESS_KEY" ] && echo "AWS creds: AWS_SECRET_ACCESS_KEY set" || echo "AWS creds: AWS_SECRET_ACCESS_KEY NOT set"
           echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
 
       - name: Set up Terraform
@@ -54,18 +59,38 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -var="github_token=$GITHUB_TOKEN" -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY"
+        # security-hotfix (cycle-3, 2026-06-01): OPENAI_API_KEY 를 -var 로 주입해 terraform 이 키를 알도록 함.
+        # 이렇게 하면 plan 이 AWS 실제 상태와 drift 없이 인식해 평문 실값을 diff 로 노출하지 않음.
+        run: |
+          terraform plan -no-color \
+            -var="github_token=$GITHUB_TOKEN" \
+            -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY" \
+            -var="openai_api_key=$OPENAI_API_KEY" \
+            -detailed-exitcode 2>&1 | tee /tmp/plan_output.txt
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
         working-directory: infra
 
-      - name: Add Plan Comment
+      # security-hotfix (cycle-3, 2026-06-01): PR 코멘트에 plan stdout 전체를 게시하지 않음.
+      # 이전 방식(marocchino/sticky-pull-request-comment + steps.plan.outputs.stdout)은
+      # terraform refresh 결과에 포함된 Lambda env 실값(OPENAI_API_KEY 등)을 PR 공개면에 노출시킴.
+      # 변경: plan 성공/실패 + exit code 요약만 게시. 상세 출력은 Actions 로그에서만 확인 가능
+      # (Actions 로그는 repo read 권한 필요 — 공개 PR 코멘트보다 노출면 크게 축소).
+      - name: Add Plan Summary Comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
             ### Terraform Plan
-            ```
-            ${{ steps.plan.outputs.stdout }}
-            ```
+
+            **Exit code**: `${{ steps.plan.outputs.exitcode }}`
+
+            | Exit code | 의미 |
+            |---|---|
+            | 0 | 변경 없음 |
+            | 1 | 오류 |
+            | 2 | 변경 있음 (apply 필요) |
+
+            상세 plan 출력은 Actions 로그에서 확인하세요 (보안상 PR 코멘트에 포함하지 않습니다).
 
       # ⚠️ 자동 apply 임시 비활성화 (cycle-2, 2026-05-15)
       # 사유: state ↔ AWS 사이 큰 drift 존재. 머지 시 자동 apply 가 다음 위험을 유발:
@@ -75,5 +100,9 @@ jobs:
       # 그동안 인프라 변경이 필요하면 workflow_dispatch 로 plan 만 돌리고 수동 apply.
       - name: Terraform Apply
         if: false  # disabled — see comment above
-        run: terraform apply -auto-approve -var="github_token=$GITHUB_TOKEN" -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY"
-        working-directory: infra 
+        run: |
+          terraform apply -auto-approve \
+            -var="github_token=$GITHUB_TOKEN" \
+            -var="google_fonts_api_key=$GOOGLE_FONTS_API_KEY" \
+            -var="openai_api_key=$OPENAI_API_KEY"
+        working-directory: infra

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
-auto_video_create_server/.env .terraform/
+auto_video_create_server/.env
+.terraform/
 
 # Python bytecode
 *.pyc
@@ -11,3 +12,9 @@ __pycache__/
 auto_video_create_server/lambda/
 lambda.zip
 infra/.terraform/
+
+# Terraform — 실값 파일 커밋 금지
+terraform.tfvars
+*.auto.tfvars
+infra/terraform.tfvars
+infra/*.auto.tfvars

--- a/auto_video_create_front/package-lock.json
+++ b/auto_video_create_front/package-lock.json
@@ -12,10 +12,12 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
+        "@types/react-window": "^1.8.8",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-confetti": "^6.4.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-window": "^1.8.11"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1564,6 +1566,15 @@
       "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "license": "MIT",
       "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "license": "MIT",
+      "dependencies": {
         "@types/react": "*"
       }
     },
@@ -4544,6 +4555,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5112,6 +5129,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/auto_video_create_front/package.json
+++ b/auto_video_create_front/package.json
@@ -14,10 +14,12 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
+    "@types/react-window": "^1.8.8",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-confetti": "^6.4.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-window": "^1.8.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/auto_video_create_front/src/app/components/FontPickerModal.tsx
+++ b/auto_video_create_front/src/app/components/FontPickerModal.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import {
+  Box,
+  Typography,
+  Dialog,
+  DialogContent,
+  IconButton,
+  CircularProgress,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import CheckIcon from "@mui/icons-material/Check";
+import SearchIcon from "@mui/icons-material/Search";
+import { FixedSizeList, ListChildComponentProps } from "react-window";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface FontItem {
+  family: string;
+  category: string;
+  slug: string;
+}
+
+type TabValue = "All" | "serif" | "sans-serif" | "display" | "handwriting" | "monospace";
+
+const TABS: { label: string; value: TabValue }[] = [
+  { label: "All", value: "All" },
+  { label: "Serif", value: "serif" },
+  { label: "Sans serif", value: "sans-serif" },
+  { label: "Display", value: "display" },
+  { label: "Handwriting", value: "handwriting" },
+  { label: "Monospace", value: "monospace" },
+];
+
+const ITEM_HEIGHT = 56;
+const MODAL_LIST_HEIGHT = 340;
+
+// ── FontRow ────────────────────────────────────────────────────────────────
+
+interface FontRowProps {
+  font: FontItem;
+  isSelected: boolean;
+  onSelect: (family: string) => void;
+  onFontLoad: (family: string) => void;
+}
+
+const FontRow = React.memo(function FontRow({
+  font,
+  isSelected,
+  onSelect,
+  onFontLoad,
+}: FontRowProps) {
+  const [imgError, setImgError] = useState(false);
+  const thumbnailUrl = `https://creatomate.com/files/fonts/${font.slug}.png`;
+
+  // Trigger font load when row becomes visible
+  useEffect(() => {
+    onFontLoad(font.family);
+  }, [font.family, onFontLoad]);
+
+  return (
+    <Box
+      onClick={() => onSelect(font.family)}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        height: ITEM_HEIGHT,
+        px: 2.5,
+        cursor: "pointer",
+        bgcolor: isSelected ? "rgba(25,118,210,0.07)" : "transparent",
+        "&:hover": { bgcolor: isSelected ? "rgba(25,118,210,0.1)" : "#f5f7fa" },
+        transition: "background 0.12s",
+        gap: 2,
+        userSelect: "none",
+      }}
+    >
+      {/* Thumbnail or font text */}
+      {!imgError ? (
+        <Box
+          sx={{
+            width: 120,
+            height: 36,
+            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+            overflow: "hidden",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={thumbnailUrl}
+            alt={font.family}
+            onError={() => setImgError(true)}
+            style={{
+              width: "100%",
+              height: "100%",
+              objectFit: "contain",
+              objectPosition: "left center",
+            }}
+            loading="lazy"
+          />
+        </Box>
+      ) : null}
+
+      {/* Font name */}
+      <Typography
+        sx={{
+          flex: 1,
+          fontSize: 14,
+          color: "#222",
+          fontFamily: `'${font.family}', sans-serif`,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {font.family}
+      </Typography>
+
+      {/* Check */}
+      {isSelected && (
+        <CheckIcon sx={{ color: "#1976d2", fontSize: 18, flexShrink: 0 }} />
+      )}
+    </Box>
+  );
+});
+
+// ── Main Modal ─────────────────────────────────────────────────────────────
+
+interface FontPickerModalProps {
+  open: boolean;
+  fonts: FontItem[];
+  loading: boolean;
+  selectedFont: string;
+  onSelect: (fontFamily: string) => void;
+  onClose: () => void;
+}
+
+export default function FontPickerModal({
+  open,
+  fonts,
+  loading,
+  selectedFont,
+  onSelect,
+  onClose,
+}: FontPickerModalProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeTab, setActiveTab] = useState<TabValue>("All");
+  const listRef = useRef<FixedSizeList>(null);
+  const loadedFontsRef = useRef<Set<string>>(new Set());
+
+  // Reset search/tab when modal opens
+  useEffect(() => {
+    if (open) {
+      setSearchQuery("");
+      setActiveTab("All");
+    }
+  }, [open]);
+
+  // Scroll to selected item when fonts load or modal opens
+  useEffect(() => {
+    if (open && fonts.length > 0 && listRef.current) {
+      const idx = fonts.findIndex((f) => f.family === selectedFont);
+      if (idx !== -1) {
+        listRef.current.scrollToItem(idx, "smart");
+      }
+    }
+  }, [open, fonts, selectedFont]);
+
+  // Filter fonts based on search + tab
+  const filteredFonts = useMemo(() => {
+    let list = fonts;
+    if (activeTab !== "All") {
+      list = list.filter((f) => f.category === activeTab);
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase();
+      list = list.filter((f) => f.family.toLowerCase().includes(q));
+    }
+    return list;
+  }, [fonts, activeTab, searchQuery]);
+
+  // Reset scroll on filter change
+  useEffect(() => {
+    listRef.current?.scrollTo(0);
+  }, [searchQuery, activeTab]);
+
+  const handleFontLoad = useCallback((family: string) => {
+    if (loadedFontsRef.current.has(family)) return;
+    loadedFontsRef.current.add(family);
+    // Dynamically inject font-face for this family
+    const linkId = `gfont-${family.replace(/\s+/g, "-").toLowerCase()}`;
+    if (!document.getElementById(linkId)) {
+      const link = document.createElement("link");
+      link.id = linkId;
+      link.rel = "stylesheet";
+      link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family).replace(/%20/g, "+")}:wght@400;700&display=swap`;
+      document.head.appendChild(link);
+    }
+  }, []);
+
+  const Row = useCallback(
+    ({ index, style }: ListChildComponentProps) => {
+      const font = filteredFonts[index];
+      return (
+        <div style={style}>
+          <FontRow
+            font={font}
+            isSelected={font.family === selectedFont}
+            onSelect={onSelect}
+            onFontLoad={handleFontLoad}
+          />
+        </div>
+      );
+    },
+    [filteredFonts, selectedFont, onSelect, handleFontLoad]
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      PaperProps={{
+        sx: {
+          width: 560,
+          maxHeight: "70vh",
+          borderRadius: "16px",
+          boxShadow: "0 16px 48px rgba(0,0,0,0.20)",
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+        },
+      }}
+      sx={{
+        "& .MuiBackdrop-root": { bgcolor: "rgba(0,0,0,0.45)" },
+        zIndex: 300,
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 2.5,
+          height: 56,
+          borderBottom: "1px solid #f2f4f8",
+          flexShrink: 0,
+        }}
+      >
+        <Typography sx={{ fontSize: 16, fontWeight: 700, color: "#222" }}>
+          폰트 선택
+        </Typography>
+        <IconButton size="small" onClick={onClose} sx={{ color: "#666" }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      <DialogContent
+        sx={{ p: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}
+      >
+        {/* Search */}
+        <Box sx={{ px: 2.5, pt: 2, pb: 1.5 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              border: "1.5px solid #e3e6ef",
+              borderRadius: "8px",
+              px: 1.5,
+              height: 44,
+              gap: 1,
+              "&:focus-within": {
+                borderColor: "#1976d2",
+                boxShadow: "0 0 0 2px rgba(25,118,210,0.12)",
+              },
+            }}
+          >
+            <SearchIcon sx={{ color: "#999", fontSize: 18 }} />
+            <input
+              type="text"
+              placeholder="폰트 검색"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              style={{
+                flex: 1,
+                border: "none",
+                outline: "none",
+                background: "transparent",
+                fontSize: 14,
+                color: "#222",
+              }}
+            />
+            {searchQuery && (
+              <Box
+                onClick={() => setSearchQuery("")}
+                sx={{ cursor: "pointer", color: "#999", fontSize: 16, lineHeight: 1 }}
+              >
+                ×
+              </Box>
+            )}
+          </Box>
+        </Box>
+
+        {/* Category tabs */}
+        <Box
+          sx={{
+            display: "flex",
+            borderBottom: "1px solid #f2f4f8",
+            px: 1,
+            flexShrink: 0,
+            overflowX: "auto",
+          }}
+        >
+          {TABS.map((tab) => (
+            <Box
+              key={tab.value}
+              onClick={() => setActiveTab(tab.value)}
+              sx={{
+                px: 1.5,
+                height: 40,
+                display: "flex",
+                alignItems: "center",
+                cursor: "pointer",
+                borderBottom:
+                  activeTab === tab.value ? "2px solid #1976d2" : "2px solid transparent",
+                color: activeTab === tab.value ? "#1976d2" : "#666",
+                fontWeight: activeTab === tab.value ? 700 : 400,
+                fontSize: 13,
+                whiteSpace: "nowrap",
+                transition: "color 0.15s",
+                userSelect: "none",
+              }}
+            >
+              {tab.label}
+            </Box>
+          ))}
+        </Box>
+
+        {/* Font list */}
+        <Box sx={{ flex: 1, overflow: "hidden" }}>
+          {loading ? (
+            <Box
+              sx={{
+                height: MODAL_LIST_HEIGHT,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <CircularProgress size={28} />
+            </Box>
+          ) : filteredFonts.length === 0 ? (
+            <Box
+              sx={{
+                height: MODAL_LIST_HEIGHT,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Typography sx={{ color: "#999", fontSize: 14 }}>
+                검색 결과가 없습니다.
+              </Typography>
+            </Box>
+          ) : (
+            <FixedSizeList
+              ref={listRef}
+              height={MODAL_LIST_HEIGHT}
+              width="100%"
+              itemCount={filteredFonts.length}
+              itemSize={ITEM_HEIGHT}
+            >
+              {Row}
+            </FixedSizeList>
+          )}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
+++ b/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
@@ -1,0 +1,731 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Box,
+  Typography,
+  Collapse,
+  ToggleButtonGroup,
+  ToggleButton,
+  Snackbar,
+  Alert,
+} from "@mui/material";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import FontPickerModal from "./FontPickerModal";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface StyleSetting {
+  font_family: string;
+  font_size: "S" | "M" | "L";
+  fill_color: string;
+}
+
+export interface SubtitleSettings {
+  title: StyleSetting;
+  subtitle: StyleSetting;
+}
+
+interface FontItem {
+  family: string;
+  category: string;
+  slug: string;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const DEFAULT_SETTINGS: SubtitleSettings = {
+  title: { font_family: "Black Han Sans", font_size: "M", fill_color: "#fff100" },
+  subtitle: { font_family: "Noto Sans KR", font_size: "M", fill_color: "#ffffff" },
+};
+
+// CSS px values for the 9:16 preview frame (240px wide)
+const SIZE_PX: Record<"S" | "M" | "L", { title: number; subtitle: number }> = {
+  S: { title: 20, subtitle: 14 },
+  M: { title: 26, subtitle: 18 },
+  L: { title: 34, subtitle: 24 },
+};
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+
+function authFetch(url: string, options: RequestInit = {}) {
+  const userId = typeof window !== "undefined" ? localStorage.getItem("user_id") : null;
+  return fetch(url, {
+    ...options,
+    headers: { ...(options.headers || {}), "X-USER-ID": userId ?? "" },
+  });
+}
+
+// ── MiniChip ──────────────────────────────────────────────────────────────
+
+function MiniChip({
+  label,
+  fontFamily,
+  color,
+}: {
+  label: string;
+  fontFamily: string;
+  color: string;
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0.25 }}>
+      <Typography
+        sx={{ fontSize: 9, color: "#aaa", lineHeight: 1, userSelect: "none" }}
+      >
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          bgcolor: "#3a3a3a",
+          border: "1px solid rgba(255,255,255,0.15)",
+          borderRadius: "6px",
+          px: "10px",
+          py: "4px",
+          minWidth: 48,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: `'${fontFamily}', sans-serif`,
+            color,
+            fontSize: 13,
+            fontWeight: 700,
+            lineHeight: 1,
+            userSelect: "none",
+          }}
+        >
+          가나다
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+// ── ColorSwatch ───────────────────────────────────────────────────────────
+
+function ColorSwatch({
+  label,
+  color,
+  onChange,
+}: {
+  label: string;
+  color: string;
+  onChange: (hex: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <Box>
+      <Typography sx={{ fontSize: 12, color: "#666", mb: 0.5 }}>{label}</Typography>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          border: "1.5px solid #e3e6ef",
+          borderRadius: "7px",
+          px: 1.5,
+          py: 0.75,
+          cursor: "pointer",
+          "&:hover": { borderColor: "#1976d2" },
+        }}
+        onClick={() => inputRef.current?.click()}
+      >
+        <Box
+          sx={{
+            width: 24,
+            height: 24,
+            borderRadius: "4px",
+            bgcolor: color,
+            border: "1px solid rgba(0,0,0,0.15)",
+            flexShrink: 0,
+          }}
+        />
+        <Typography sx={{ fontSize: 13, color: "#444", fontFamily: "monospace" }}>
+          {color.toUpperCase()}
+        </Typography>
+        <input
+          ref={inputRef}
+          type="color"
+          value={color}
+          style={{ position: "absolute", opacity: 0, width: 0, height: 0, pointerEvents: "none" }}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+// ── StyleSection ──────────────────────────────────────────────────────────
+
+function StyleSection({
+  sectionLabel,
+  setting,
+  onChange,
+  onOpenFontPicker,
+}: {
+  sectionLabel: string;
+  setting: StyleSetting;
+  onChange: (patch: Partial<StyleSetting>) => void;
+  onOpenFontPicker: () => void;
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Typography
+        sx={{
+          fontSize: 13,
+          fontWeight: 700,
+          color: "#1976d2",
+          letterSpacing: 0.2,
+          textTransform: "uppercase",
+        }}
+      >
+        {sectionLabel}
+      </Typography>
+
+      {/* 폰트 */}
+      <Box>
+        <Typography sx={{ fontSize: 12, color: "#666", mb: 0.5 }}>폰트</Typography>
+        <Box
+          onClick={onOpenFontPicker}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            border: "1.5px solid #e3e6ef",
+            borderRadius: "7px",
+            px: 1.5,
+            py: 0.75,
+            cursor: "pointer",
+            bgcolor: "#fff",
+            "&:hover": { borderColor: "#1976d2", boxShadow: "0 0 0 2px rgba(25,118,210,0.12)" },
+            transition: "all 0.15s",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: `'${setting.font_family}', sans-serif`,
+              fontSize: 14,
+              color: "#222",
+              flex: 1,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {setting.font_family}
+          </Typography>
+          <Typography sx={{ fontSize: 16, color: "#666", ml: 1, flexShrink: 0 }}>↗</Typography>
+        </Box>
+      </Box>
+
+      {/* 크기 */}
+      <Box>
+        <Typography sx={{ fontSize: 12, color: "#666", mb: 0.5 }}>크기</Typography>
+        <ToggleButtonGroup
+          value={setting.font_size}
+          exclusive
+          onChange={(_, v) => { if (v) onChange({ font_size: v as "S" | "M" | "L" }); }}
+          size="small"
+          sx={{ width: "100%" }}
+        >
+          {(["S", "M", "L"] as const).map((sz) => (
+            <ToggleButton
+              key={sz}
+              value={sz}
+              sx={{
+                flex: 1,
+                fontSize: 13,
+                fontWeight: 600,
+                border: "1.5px solid #e3e6ef !important",
+                borderRadius: "7px !important",
+                mx: 0.25,
+                "&.Mui-selected": {
+                  bgcolor: "#1976d2 !important",
+                  color: "#fff !important",
+                  borderColor: "#1976d2 !important",
+                },
+                "&:hover": { borderColor: "#1976d2 !important" },
+              }}
+            >
+              {sz === "S" ? "S 작게" : sz === "M" ? "M 보통" : "L 크게"}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+
+      {/* 색상 */}
+      <ColorSwatch
+        label="색상"
+        color={setting.fill_color}
+        onChange={(hex) => onChange({ fill_color: hex })}
+      />
+    </Box>
+  );
+}
+
+// ── Preview9x16 ───────────────────────────────────────────────────────────
+
+function Preview9x16({ settings }: { settings: SubtitleSettings }) {
+  const titlePx = SIZE_PX[settings.title.font_size].title;
+  const subtitlePx = SIZE_PX[settings.subtitle.font_size].subtitle;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        position: "sticky",
+        top: 80,
+      }}
+    >
+      <Typography
+        sx={{ fontSize: 12, color: "#666", fontWeight: 600, mb: 1 }}
+      >
+        미리보기
+      </Typography>
+
+      {/* 9:16 frame */}
+      <Box
+        sx={{
+          width: 240,
+          height: 426,
+          border: "2px solid #dde1ea",
+          borderRadius: "12px",
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+          bgcolor: "#4a4a4a",
+          position: "relative",
+        }}
+      >
+        {/* 미리보기 레이블 pill */}
+        <Box
+          sx={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            bgcolor: "#888",
+            color: "#fff",
+            fontSize: 10,
+            px: 1,
+            py: 0.25,
+            borderRadius: 999,
+            zIndex: 2,
+          }}
+        >
+          미리보기
+        </Box>
+
+        {/* 상단: 제목 존 */}
+        <Box
+          sx={{
+            bgcolor: "rgba(0,0,0,0.40)",
+            px: 1.5,
+            py: 1,
+            minHeight: "20%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: `'${settings.title.font_family}', sans-serif`,
+              fontSize: titlePx,
+              color: settings.title.fill_color,
+              textAlign: "center",
+              wordBreak: "keep-all",
+              lineHeight: 1.3,
+            }}
+          >
+            양재역 맛집 소개
+          </Typography>
+        </Box>
+
+        {/* 중앙: 이미지 placeholder */}
+        <Box
+          sx={{
+            flex: 1,
+            bgcolor: "#b0b8c4",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 0.5,
+          }}
+        >
+          <Typography sx={{ fontSize: 20, color: "#888" }}>📷</Typography>
+          <Typography
+            sx={{
+              fontSize: 10,
+              color: "#666",
+              textAlign: "center",
+              px: 1,
+              lineHeight: 1.4,
+            }}
+          >
+            이미지를 선택하면
+            <br />
+            여기에 반영됩니다
+          </Typography>
+        </Box>
+
+        {/* 하단: 자막 존 */}
+        <Box
+          sx={{
+            bgcolor: "rgba(0,0,0,0.40)",
+            px: 1.5,
+            py: 1,
+            minHeight: "20%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: `'${settings.subtitle.font_family}', sans-serif`,
+              fontSize: subtitlePx,
+              color: settings.subtitle.fill_color,
+              textAlign: "center",
+              wordBreak: "keep-all",
+              lineHeight: 1.3,
+            }}
+          >
+            양계옥 최고 맛집 소개합니다.
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* 미리보기 한계 안내 */}
+      <Typography
+        sx={{ fontSize: 11, color: "#888", mt: 1, textAlign: "center", maxWidth: 240 }}
+      >
+        실제 영상과 유사한 미리보기입니다.
+        <br />
+        렌더링 결과는 차이가 있을 수 있어요.
+      </Typography>
+    </Box>
+  );
+}
+
+// ── SubtitleStyleEditor (Main) ────────────────────────────────────────────
+
+interface SubtitleStyleEditorProps {
+  onSettingsChange: (settings: SubtitleSettings) => void;
+}
+
+export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleEditorProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [settings, setSettings] = useState<SubtitleSettings>(DEFAULT_SETTINGS);
+  const [fonts, setFonts] = useState<FontItem[]>([]);
+  const [fontsLoading, setFontsLoading] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerTarget, setPickerTarget] = useState<"title" | "subtitle">("title");
+  const [toastOpen, setToastOpen] = useState(false);
+  const [hasChanged, setHasChanged] = useState(false);
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isDefaultSettings = useCallback((s: SubtitleSettings) => {
+    return (
+      s.title.font_family === DEFAULT_SETTINGS.title.font_family &&
+      s.title.font_size === DEFAULT_SETTINGS.title.font_size &&
+      s.title.fill_color === DEFAULT_SETTINGS.title.fill_color &&
+      s.subtitle.font_family === DEFAULT_SETTINGS.subtitle.font_family &&
+      s.subtitle.font_size === DEFAULT_SETTINGS.subtitle.font_size &&
+      s.subtitle.fill_color === DEFAULT_SETTINGS.subtitle.fill_color
+    );
+  }, []);
+
+  // Load settings on mount
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/blog/subtitle-settings`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.settings) {
+          const loaded: SubtitleSettings = {
+            title: {
+              font_family: data.settings.title?.font_family ?? DEFAULT_SETTINGS.title.font_family,
+              font_size: (data.settings.title?.font_size as "S" | "M" | "L") ?? "M",
+              fill_color: data.settings.title?.fill_color ?? DEFAULT_SETTINGS.title.fill_color,
+            },
+            subtitle: {
+              font_family: data.settings.subtitle?.font_family ?? DEFAULT_SETTINGS.subtitle.font_family,
+              font_size: (data.settings.subtitle?.font_size as "S" | "M" | "L") ?? "M",
+              fill_color: data.settings.subtitle?.fill_color ?? DEFAULT_SETTINGS.subtitle.fill_color,
+            },
+          };
+          setSettings(loaded);
+          onSettingsChange(loaded);
+          setHasChanged(!isDefaultSettings(loaded));
+        }
+      } catch {
+        // silently fall back to defaults
+      }
+    };
+    load();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Load fonts when picker is first opened
+  const loadFonts = useCallback(async () => {
+    if (fonts.length > 0) return;
+    setFontsLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE_URL}/api/blog/fonts`);
+      if (!res.ok) throw new Error("fonts API failed");
+      const data = await res.json();
+      if (Array.isArray(data.fonts)) {
+        setFonts(data.fonts);
+      }
+    } catch {
+      // fallback: show empty list; user can still use font name entry
+    } finally {
+      setFontsLoading(false);
+    }
+  }, [fonts.length]);
+
+  const debouncedSave = useCallback((newSettings: SubtitleSettings) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/blog/subtitle-settings`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newSettings),
+        });
+        if (res.ok) setToastOpen(true);
+      } catch {
+        // ignore save errors silently
+      }
+    }, 500);
+  }, []);
+
+  const updateSection = useCallback(
+    (section: "title" | "subtitle", patch: Partial<StyleSetting>) => {
+      setSettings((prev) => {
+        const next = {
+          ...prev,
+          [section]: { ...prev[section], ...patch },
+        };
+        onSettingsChange(next);
+        setHasChanged(!isDefaultSettings(next));
+        debouncedSave(next);
+        return next;
+      });
+    },
+    [onSettingsChange, isDefaultSettings, debouncedSave]
+  );
+
+  const handleReset = () => {
+    setSettings(DEFAULT_SETTINGS);
+    onSettingsChange(DEFAULT_SETTINGS);
+    setHasChanged(false);
+    debouncedSave(DEFAULT_SETTINGS);
+  };
+
+  const handleOpenPicker = (target: "title" | "subtitle") => {
+    setPickerTarget(target);
+    setPickerOpen(true);
+    loadFonts();
+  };
+
+  const handleFontSelect = (fontFamily: string) => {
+    updateSection(pickerTarget, { font_family: fontFamily });
+    setPickerOpen(false);
+  };
+
+  return (
+    <>
+      {/* Collapse card */}
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: 1200,
+          mx: "auto",
+          mb: 2,
+          borderRadius: expanded ? "12px 12px 0 0" : "12px",
+          border: "1.5px solid #f2f4f8",
+          bgcolor: "#fafbfc",
+          boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
+          overflow: "hidden",
+        }}
+      >
+        {/* Header (always visible) */}
+        <Box
+          onClick={() => setExpanded((v) => !v)}
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            px: 3,
+            height: 56,
+            cursor: "pointer",
+            userSelect: "none",
+            gap: 1.5,
+            "&:hover": { bgcolor: "#f0f2f5" },
+            transition: "background 0.15s",
+          }}
+        >
+          {/* Label + badge */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexShrink: 0 }}>
+            <Typography sx={{ fontSize: 15, fontWeight: 700, color: "#222" }}>
+              자막 스타일 설정
+            </Typography>
+            <Box
+              sx={{
+                bgcolor: "#f0f4f8",
+                border: "1px solid #dde1ea",
+                borderRadius: 999,
+                px: 1,
+                py: 0.125,
+              }}
+            >
+              <Typography sx={{ fontSize: 11, color: "#888", lineHeight: 1.4 }}>
+                선택 사항
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Mini chips */}
+          <Box sx={{ display: "flex", gap: 1, flex: 1, justifyContent: "center" }}>
+            <MiniChip
+              label="제목"
+              fontFamily={settings.title.font_family}
+              color={settings.title.fill_color}
+            />
+            <MiniChip
+              label="자막"
+              fontFamily={settings.subtitle.font_family}
+              color={settings.subtitle.fill_color}
+            />
+          </Box>
+
+          {/* Toggle icon */}
+          {expanded ? (
+            <KeyboardArrowUpIcon sx={{ color: "#666", fontSize: 20, flexShrink: 0 }} />
+          ) : (
+            <KeyboardArrowDownIcon sx={{ color: "#666", fontSize: 20, flexShrink: 0 }} />
+          )}
+        </Box>
+
+        {/* Expanded content */}
+        <Collapse in={expanded} timeout={250}>
+          <Box
+            sx={{
+              borderTop: "1.5px solid #f2f4f8",
+              display: "flex",
+              flexDirection: "row",
+              gap: 0,
+            }}
+          >
+            {/* Left: 6 controls */}
+            <Box
+              sx={{
+                flex: "0 0 45%",
+                minWidth: 360,
+                p: 3,
+                display: "flex",
+                flexDirection: "column",
+                gap: 0,
+              }}
+            >
+              {/* 제목 자막 section */}
+              <StyleSection
+                sectionLabel="제목 자막"
+                setting={settings.title}
+                onChange={(patch) => updateSection("title", patch)}
+                onOpenFontPicker={() => handleOpenPicker("title")}
+              />
+
+              {/* Divider */}
+              <Box sx={{ borderTop: "1px solid #e3e6ef", my: 3 }} />
+
+              {/* 본문 자막 section */}
+              <StyleSection
+                sectionLabel="본문 자막"
+                setting={settings.subtitle}
+                onChange={(patch) => updateSection("subtitle", patch)}
+                onOpenFontPicker={() => handleOpenPicker("subtitle")}
+              />
+
+              {/* Reset button */}
+              {hasChanged && (
+                <Box sx={{ mt: 3 }}>
+                  <Typography
+                    onClick={handleReset}
+                    sx={{
+                      fontSize: 13,
+                      color: "text.secondary",
+                      cursor: "pointer",
+                      textDecoration: "underline",
+                      display: "inline",
+                      "&:hover": { color: "#1976d2" },
+                    }}
+                  >
+                    기본값으로 초기화
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+
+            {/* Divider vertical */}
+            <Box sx={{ width: "1px", bgcolor: "#e3e6ef", my: 3 }} />
+
+            {/* Right: 9:16 preview */}
+            <Box sx={{ flex: 1, p: 3, display: "flex", justifyContent: "center" }}>
+              <Preview9x16 settings={settings} />
+            </Box>
+          </Box>
+        </Collapse>
+      </Box>
+
+      {/* FontPickerModal */}
+      <FontPickerModal
+        open={pickerOpen}
+        fonts={fonts}
+        loading={fontsLoading}
+        selectedFont={pickerTarget === "title" ? settings.title.font_family : settings.subtitle.font_family}
+        onSelect={handleFontSelect}
+        onClose={() => setPickerOpen(false)}
+      />
+
+      {/* Save toast */}
+      <Snackbar
+        open={toastOpen}
+        autoHideDuration={1500}
+        onClose={() => setToastOpen(false)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          onClose={() => setToastOpen(false)}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
+          저장됐어요
+        </Alert>
+      </Snackbar>
+
+      {/* Load Google Fonts for default fonts */}
+      <style>{`
+        @import url('https://fonts.googleapis.com/css2?family=Black+Han+Sans&family=Noto+Sans+KR:wght@400;700&display=swap');
+      `}</style>
+
+      {/* Dynamically load selected fonts */}
+      {[settings.title.font_family, settings.subtitle.font_family]
+        .filter((f) => f !== "Black Han Sans" && f !== "Noto Sans KR")
+        .map((f) => (
+          <style key={f}>{`
+            @import url('https://fonts.googleapis.com/css2?family=${encodeURIComponent(f).replace(/%20/g, "+")}:wght@400;700&display=swap');
+          `}</style>
+        ))}
+
+    </>
+  );
+}

--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -71,9 +71,6 @@ export default function Home() {
     subtitle: { font_family: "Noto Sans KR", font_size: "M", fill_color: "#ffffff" },
   });
 
-  console.log("--- Component Re-rendering ---");
-  console.log("Current sectionMedia state:", JSON.stringify(sectionMedia, null, 2));
-
   useEffect(() => {
     if (typeof window !== "undefined") {
       setIsLoggedIn(!!localStorage.getItem("user_id"));

--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -10,6 +10,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import ZoomInIcon from '@mui/icons-material/ZoomIn';
 import AuthGuard from "../components/AuthGuard";
 import LogoutButton from "../components/LogoutButton";
+import SubtitleStyleEditor, { SubtitleSettings } from "./components/SubtitleStyleEditor";
 
 interface MediaList {
   images: string[];
@@ -63,6 +64,12 @@ export default function Home() {
 
   // sectionMedia: 길이 5, 각 원소는 SectionMedia 또는 null
   const [sectionMedia, setSectionMedia] = useState<(SectionMedia|null)[]>([null, null, null, null, null]);
+
+  // cycle-3: 자막 스타일 설정
+  const [subtitleSettings, setSubtitleSettings] = useState<SubtitleSettings>({
+    title: { font_family: "Black Han Sans", font_size: "M", fill_color: "#fff100" },
+    subtitle: { font_family: "Noto Sans KR", font_size: "M", fill_color: "#ffffff" },
+  });
 
   console.log("--- Component Re-rendering ---");
   console.log("Current sectionMedia state:", JSON.stringify(sectionMedia, null, 2));
@@ -188,6 +195,7 @@ export default function Home() {
           title,
           scripts,
           sections: sectionMedia,
+          subtitle_settings: subtitleSettings,
         }),
         signal: controller.signal,
       });
@@ -364,7 +372,10 @@ export default function Home() {
                   {/* 왼쪽: 타이틀+안내문구 */}
                   <Box>
                     <Typography variant="h5" fontWeight={700} sx={{ color: '#222', letterSpacing: -1, mb: 0.5 }}>
-                    생성된 스크립트에 알맞는 이미지 또는 영상을 순서대로 선택해 주세요.
+                      생성된 스크립트에 알맞는 이미지를 선택해 주세요.
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: '#666' }}>
+                      자막 스타일을 미리 설정하고 이미지를 선택하면 영상이 생성됩니다.
                     </Typography>
                   </Box>
                   {/* 오른쪽: 액션 버튼 2개 */}
@@ -389,7 +400,18 @@ export default function Home() {
                     </Button>
                   </Box>
                 </Box>
-                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'flex-start', gap: 4, px: 4, py: 6, maxWidth: 1200, mx: 'auto', width: '100%' }}>
+                {/* cycle-3: 자막 스타일 설정 (Row 1 — 접힘 기본) */}
+                <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
+                  <SubtitleStyleEditor onSettingsChange={setSubtitleSettings} />
+                  {/* Row 경계 시선 유도 */}
+                  <Typography
+                    variant="body2"
+                    sx={{ color: '#666', mb: 2, fontSize: 13 }}
+                  >
+                    이미지를 선택해 주세요 — 5개를 모두 고르면 영상 생성하기가 활성화됩니다.
+                  </Typography>
+                </Box>
+                <Box sx={{ flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'flex-start', gap: 4, px: 4, py: 2, maxWidth: 1200, mx: 'auto', width: '100%' }}>
                   {/* 왼쪽: 스크립트 */}
                   <Paper elevation={3} sx={{ flex: 1, p: 4, borderRadius: 4, minWidth: 340, maxWidth: 480, bgcolor: '#fafbfc', boxShadow: '0 4px 24px rgba(0,0,0,0.04)' }}>
                     <Typography variant="h6" fontWeight={700} gutterBottom>생성된 스크립트</Typography>

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -7,10 +7,18 @@ from services.create_creatomate_video import create_creatomate_video, get_creato
 from services.account_service import get_user_if_active, check_user_credits, get_current_credits
 from services.ai_background import generate_backgrounds_parallel, FALLBACK_URL as DEFAULT_BG_FALLBACK_URL
 from services.image_mirror import maybe_mirror
+# cycle-3: 자막 스타일 편집 신규 서비스
+from services.font_service import get_korean_fonts, get_allowed_font_families
+from services.subtitle_settings_service import (
+    get_subtitle_settings,
+    save_subtitle_settings,
+    validate_subtitle_settings,
+    apply_subtitle_settings_to_variables,
+)
 from crawler.dispatcher import UnsupportedPlatformError
 from utils.s3_utils import load_json_from_s3
 import os
-from typing import List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal
 import requests
 import traceback
 from urllib.parse import urlparse
@@ -183,11 +191,33 @@ def extract_all(req: ExtractMediaRequest, user=Depends(require_active_subscripti
     finally:
         print("extract_all finally 블록 실행")
 
+# ─────────────────────────────────────────────
+# cycle-3: 자막 스타일 관련 Pydantic 모델
+# ─────────────────────────────────────────────
+
+class TextStyleModel(BaseModel):
+    font_family: str
+    font_size: str       # "S" / "M" / "L"
+    fill_color: str      # "#RRGGBB"
+
+
+class SubtitleSettingsModel(BaseModel):
+    title: TextStyleModel
+    subtitle: TextStyleModel
+
+
+class SubtitleSettingsRequest(BaseModel):
+    title: TextStyleModel
+    subtitle: TextStyleModel
+
+
 # --- 최종 영상 생성 API ---
 class GenerateVideoRequest(BaseModel):
     title: str
     scripts: List[str]
     sections: List[SectionMedia]  # 5개
+    # cycle-3: optional — 없으면 Creatomate 템플릿 기본값 유지
+    subtitle_settings: Optional[SubtitleSettingsModel] = None
 
 class GenerateVideoResponse(BaseModel):
     status: str
@@ -248,7 +278,19 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
                 variables[f"image{i}.visible"] = "true"
                 variables[f"video{i}.visible"] = "false"
 
-        # 4. Creatomate 영상 생성 (user_id 전달)
+        # 4. cycle-3: subtitle_settings 가 있으면 Creatomate modifications 에 주입
+        if req.subtitle_settings:
+            apply_subtitle_settings_to_variables(
+                variables,
+                req.subtitle_settings.model_dump(),
+            )
+            print(
+                f"[generate_video] subtitle_settings 주입 완료 "
+                f"(title_font={req.subtitle_settings.title.font_family}, "
+                f"subtitle_font={req.subtitle_settings.subtitle.font_family})"
+            )
+
+        # 5. Creatomate 영상 생성 (user_id 전달)
         result = create_creatomate_video(
             audio_paths=audio_urls,
             scripts=req.scripts,
@@ -299,3 +341,93 @@ def get_user_credits(user=Depends(require_active_subscription)):
         "current_credits": current_credits,
         "required_credits": 1000
     }
+
+
+# ─────────────────────────────────────────────
+# cycle-3 신규 엔드포인트
+# ─────────────────────────────────────────────
+
+@router.get("/fonts")
+def get_fonts(user=Depends(require_active_subscription)):
+    """
+    GET /api/blog/fonts
+
+    한글 지원 폰트 목록 반환. Google Fonts API Korean subset 기반.
+    Lambda 인스턴스 레벨 메모리 캐시 (TTL=인스턴스 수명 ≒ 24h).
+
+    응답: { status: "success", fonts: [{ family, category, slug }, ...] }
+    """
+    try:
+        fonts = get_korean_fonts()
+        return {"status": "success", "fonts": fonts}
+    except Exception as e:
+        print(f"[get_fonts 에러] {e}")
+        traceback.print_exc()
+        raise HTTPException(
+            status_code=503,
+            detail="폰트 목록을 불러올 수 없습니다. 잠시 후 다시 시도해주세요.",
+        )
+
+
+@router.get("/subtitle-settings")
+def get_subtitle_settings_endpoint(user=Depends(require_active_subscription)):
+    """
+    GET /api/blog/subtitle-settings
+
+    select step 진입 시 저장된 자막 스타일 설정 로드.
+    저장값 없으면 settings=null 반환 (FE 가 기본값으로 처리).
+
+    응답: { status: "success", settings: { title: {...}, subtitle: {...} } | null }
+    """
+    user_id = user["id"]
+    try:
+        settings = get_subtitle_settings(user_id)
+        return {"status": "success", "settings": settings}
+    except Exception as e:
+        print(f"[get_subtitle_settings 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="설정을 불러올 수 없습니다.")
+
+
+@router.put("/subtitle-settings")
+def put_subtitle_settings_endpoint(
+    req: SubtitleSettingsRequest,
+    user=Depends(require_active_subscription),
+):
+    """
+    PUT /api/blog/subtitle-settings
+
+    사용자가 폰트/크기/색상을 변경할 때 계정에 저장 (FE debounce 500ms 후 호출).
+    font_family 는 GET /api/blog/fonts 응답 기반 허용 목록으로 검증.
+
+    응답: { status: "success" } 또는 422 에러
+    """
+    user_id = user["id"]
+    settings_dict = req.model_dump()
+
+    # font_family 유효성 검증 (허용 목록 = Google Fonts Korean subset)
+    try:
+        allowed_families = get_allowed_font_families()
+    except Exception:
+        # Google Fonts API 장애 시 유효성 검증 완화 (저장은 허용)
+        allowed_families = set()
+        print(f"[put_subtitle_settings] font 허용 목록 로드 실패 — 검증 완화")
+
+    errors = validate_subtitle_settings(settings_dict, allowed_families)
+    if errors:
+        raise HTTPException(
+            status_code=422,
+            detail="유효하지 않은 설정값입니다.: " + " | ".join(errors),
+        )
+
+    try:
+        success = save_subtitle_settings(user_id, settings_dict)
+        if not success:
+            raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+        return {"status": "success"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[put_subtitle_settings 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="설정을 저장할 수 없습니다.")

--- a/auto_video_create_server/requirements.txt
+++ b/auto_video_create_server/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 mangum==0.17.0
 requests
+httpx
 boto3
 python-dotenv
 mutagen

--- a/auto_video_create_server/services/font_service.py
+++ b/auto_video_create_server/services/font_service.py
@@ -1,0 +1,140 @@
+"""
+font_service.py — cycle-3 신규
+
+한글 지원 폰트 목록을 Google Fonts API에서 가져와 캐싱한다.
+
+- GOOGLE_FONTS_API_KEY 환경변수 필요.
+- Lambda 인스턴스 레벨 메모리 캐시 (lru_cache).
+  cold start 이후 첫 호출에만 Google API 실호출. 이후 동일 인스턴스는 캐시 반환.
+- API Key 없거나 호출 실패 시 FALLBACK_FONTS 반환 (graceful fallback).
+"""
+
+import os
+import logging
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────
+# 상수
+# ─────────────────────────────────────────────
+GOOGLE_FONTS_API_URL = (
+    "https://www.googleapis.com/webfonts/v1/webfonts"
+    "?subset=korean&sort=alpha"
+)
+
+# Google Fonts API 장애 / Key 미설정 시 fallback 정적 목록
+# data-model.md §6 FONT_FAMILY_ALLOWED_FALLBACK 기준
+FALLBACK_FONTS: list[dict] = [
+    {"family": "Black Han Sans",  "category": "display",     "slug": "black-han-sans"},
+    {"family": "Cute Font",       "category": "display",     "slug": "cute-font"},
+    {"family": "Do Hyeon",        "category": "sans-serif",  "slug": "do-hyeon"},
+    {"family": "Dokdo",           "category": "display",     "slug": "dokdo"},
+    {"family": "East Sea Dokdo",  "category": "handwriting", "slug": "east-sea-dokdo"},
+    {"family": "Gamja Flower",    "category": "display",     "slug": "gamja-flower"},
+    {"family": "Gothic A1",       "category": "sans-serif",  "slug": "gothic-a1"},
+    {"family": "Gowun Batang",    "category": "serif",       "slug": "gowun-batang"},
+    {"family": "Gowun Dodum",     "category": "sans-serif",  "slug": "gowun-dodum"},
+    {"family": "Hi Melody",       "category": "handwriting", "slug": "hi-melody"},
+    {"family": "IBM Plex Sans KR","category": "sans-serif",  "slug": "ibm-plex-sans-kr"},
+    {"family": "Jua",             "category": "sans-serif",  "slug": "jua"},
+    {"family": "Kirang Haerang",  "category": "display",     "slug": "kirang-haerang"},
+    {"family": "Nanum Gothic",    "category": "sans-serif",  "slug": "nanum-gothic"},
+    {"family": "Nanum Gothic Coding", "category": "monospace", "slug": "nanum-gothic-coding"},
+    {"family": "Nanum Myeongjo",  "category": "serif",       "slug": "nanum-myeongjo"},
+    {"family": "Nanum Pen Script","category": "handwriting", "slug": "nanum-pen-script"},
+    {"family": "Noto Sans KR",    "category": "sans-serif",  "slug": "noto-sans-kr"},
+    {"family": "Noto Serif KR",   "category": "serif",       "slug": "noto-serif-kr"},
+    {"family": "Orbit",           "category": "sans-serif",  "slug": "orbit"},
+    {"family": "Poor Story",      "category": "display",     "slug": "poor-story"},
+    {"family": "Prompt",          "category": "sans-serif",  "slug": "prompt"},
+    {"family": "Single Day",      "category": "display",     "slug": "single-day"},
+    {"family": "Song Myung",      "category": "serif",       "slug": "song-myung"},
+    {"family": "Stylish",         "category": "sans-serif",  "slug": "stylish"},
+    {"family": "Sunflower",       "category": "sans-serif",  "slug": "sunflower"},
+    {"family": "Tmon Mon Round New Basic", "category": "sans-serif", "slug": "tmon-mon-round-new-basic"},
+    {"family": "Yeon Sung",       "category": "display",     "slug": "yeon-sung"},
+]
+
+
+def _build_slug(family: str) -> str:
+    """Google Fonts family 이름 → Creatomate CDN 썸네일 slug 변환."""
+    return family.lower().replace(" ", "-")
+
+
+@lru_cache(maxsize=1)
+def _fetch_korean_fonts_cached() -> tuple[dict, ...]:
+    """
+    Google Fonts API를 호출하여 Korean subset 폰트 목록을 반환한다.
+    lru_cache 로 Lambda 인스턴스 수명 동안 캐시 유지.
+
+    반환 타입이 tuple인 이유: list는 hashable 하지 않아 lru_cache 불가.
+    호출 측에서 list로 변환하여 사용.
+    """
+    api_key = os.environ.get("GOOGLE_FONTS_API_KEY", "")
+    if not api_key:
+        logger.warning("[font_service] GOOGLE_FONTS_API_KEY 미설정 — fallback 반환")
+        return tuple(FALLBACK_FONTS)
+
+    try:
+        import httpx  # Lambda 레이어 또는 requirements.txt 에 포함
+        url = f"{GOOGLE_FONTS_API_URL}&key={api_key}"
+        resp = httpx.get(url, timeout=10)
+        resp.raise_for_status()
+        items = resp.json().get("items", [])
+        fonts = [
+            {
+                "family": item["family"],
+                "category": item.get("category", "sans-serif"),
+                "slug": _build_slug(item["family"]),
+            }
+            for item in items
+        ]
+        logger.info(f"[font_service] Google Fonts Korean subset 로드 완료: {len(fonts)}개")
+        return tuple(fonts)
+    except ImportError:
+        # httpx 미설치 환경 — requests 로 fallback
+        logger.warning("[font_service] httpx 미설치 — requests 로 재시도")
+        return _fetch_with_requests(api_key)
+    except Exception as e:
+        logger.error(f"[font_service] Google Fonts API 호출 실패: {e} — fallback 반환")
+        return tuple(FALLBACK_FONTS)
+
+
+def _fetch_with_requests(api_key: str) -> tuple[dict, ...]:
+    """httpx 없는 환경 대비 requests 사용 fallback."""
+    try:
+        import requests as req_lib
+        url = f"{GOOGLE_FONTS_API_URL}&key={api_key}"
+        resp = req_lib.get(url, timeout=10)
+        resp.raise_for_status()
+        items = resp.json().get("items", [])
+        fonts = [
+            {
+                "family": item["family"],
+                "category": item.get("category", "sans-serif"),
+                "slug": _build_slug(item["family"]),
+            }
+            for item in items
+        ]
+        logger.info(f"[font_service] Google Fonts Korean subset 로드 완료(requests): {len(fonts)}개")
+        return tuple(fonts)
+    except Exception as e:
+        logger.error(f"[font_service] requests fallback 실패: {e} — 정적 fallback 반환")
+        return tuple(FALLBACK_FONTS)
+
+
+def get_korean_fonts() -> list[dict]:
+    """
+    한글 지원 폰트 목록 반환. 캐시 히트 시 Google API 재호출 없음.
+    항상 list[dict] 반환 (캐시 내부는 tuple이지만 외부 인터페이스는 list).
+    """
+    return list(_fetch_korean_fonts_cached())
+
+
+def get_allowed_font_families() -> set[str]:
+    """
+    PUT /api/blog/subtitle-settings 에서 font_family 유효성 검증에 사용.
+    캐시된 폰트 목록에서 family 이름 set을 반환.
+    """
+    return {f["family"] for f in get_korean_fonts()}

--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -1,0 +1,208 @@
+"""
+subtitle_settings_service.py — cycle-3 신규
+
+사용자별 자막 스타일 설정을 S3 users.json 에서 읽고 쓴다.
+
+data-model.md §1~§3 스키마 준수.
+기존 deduct_credits / account_service 패턴(S3 read-modify-write)과 동일 방식.
+"""
+
+import json
+import logging
+import os
+import re
+from typing import Optional
+
+import boto3
+
+from utils.s3_utils import load_json_from_s3
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────
+# 상수 (data-model.md §6)
+# ─────────────────────────────────────────────
+BUCKET_USERS = "blog-to-short-form-users"
+KEY_USERS = "users.json"
+
+VALID_FONT_SIZES = {"S", "M", "L"}
+HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+# vmin 변환 테이블 (data-model.md §4)
+SIZE_MAP_SUBTITLE_VMIN: dict[str, Optional[str]] = {
+    "S": "4 vmin",
+    "M": "6 vmin",
+    "L": "8 vmin",
+}
+SIZE_MAP_TITLE_VMIN: dict[str, Optional[str]] = {
+    "S": "6 vmin",
+    "M": None,       # M → modification 미주입 = auto-fit 유지
+    "L": "12 vmin",
+}
+
+# Creatomate 자막 element 식별자 (data-model.md §6 / architecture.md DEP-01)
+SUBTITLE_SUFFIXES = ["6K5", "JTM", "MDV", "5Z2", "D6M"]
+
+# 기본값 (data-model.md §3)
+DEFAULT_TITLE_SETTINGS: dict = {
+    "font_family": "Black Han Sans",
+    "font_size": "M",
+    "fill_color": "#fff100",
+}
+DEFAULT_SUBTITLE_SETTINGS: dict = {
+    "font_family": "Noto Sans KR",
+    "font_size": "M",
+    "fill_color": "#ffffff",
+}
+
+_s3 = boto3.client(
+    "s3",
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    region_name="ap-northeast-2",
+)
+
+
+# ─────────────────────────────────────────────
+# 유효성 검증 헬퍼
+# ─────────────────────────────────────────────
+
+def _validate_text_style(style: dict, allowed_families: set[str]) -> list[str]:
+    """
+    TextStyle dict 유효성 검증. 오류 메시지 목록 반환 (빈 목록 = 통과).
+    font_family 검증은 allowed_families set 기준.
+    """
+    errors: list[str] = []
+
+    font_family = style.get("font_family", "")
+    font_size = style.get("font_size", "")
+    fill_color = style.get("fill_color", "")
+
+    if not isinstance(font_family, str) or not font_family.strip():
+        errors.append("font_family 는 비어있지 않은 문자열이어야 합니다.")
+    elif allowed_families and font_family not in allowed_families:
+        # 허용 목록이 있을 때만 검증 (Google Fonts API 장애 시 허용 목록이 비어있을 수 있음)
+        errors.append(f"허용되지 않는 font_family: {font_family!r}")
+
+    if font_size not in VALID_FONT_SIZES:
+        errors.append(f"font_size 는 S/M/L 중 하나여야 합니다. 받은 값: {font_size!r}")
+
+    if not isinstance(fill_color, str) or not HEX_COLOR_RE.match(fill_color):
+        errors.append(f"fill_color 는 #RRGGBB 형식이어야 합니다. 받은 값: {fill_color!r}")
+
+    return errors
+
+
+def validate_subtitle_settings(settings: dict, allowed_families: set[str]) -> list[str]:
+    """
+    subtitle_settings 전체 유효성 검증.
+    반환: 오류 메시지 목록 (빈 목록 = 통과).
+    """
+    errors: list[str] = []
+    for section in ("title", "subtitle"):
+        section_data = settings.get(section)
+        if not isinstance(section_data, dict):
+            errors.append(f"{section} 섹션이 누락되었거나 dict 가 아닙니다.")
+            continue
+        section_errors = _validate_text_style(section_data, allowed_families)
+        errors.extend(f"[{section}] {e}" for e in section_errors)
+    return errors
+
+
+# ─────────────────────────────────────────────
+# S3 Read / Write
+# ─────────────────────────────────────────────
+
+def get_subtitle_settings(user_id: str) -> Optional[dict]:
+    """
+    users.json 에서 user_id 에 해당하는 subtitle_settings 반환.
+    설정 없으면 None (FE 가 기본값으로 처리).
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        for user in users:
+            if user["id"] == user_id:
+                settings = user.get("subtitle_settings")
+                logger.info(
+                    f"[subtitle_settings] GET user={user_id} settings={'있음' if settings else '없음'}"
+                )
+                return settings
+        logger.warning(f"[subtitle_settings] GET user={user_id} — 사용자 없음")
+        return None
+    except Exception as e:
+        logger.error(f"[subtitle_settings] GET 실패 user={user_id}: {e}")
+        raise
+
+
+def save_subtitle_settings(user_id: str, settings: dict) -> bool:
+    """
+    users.json 에서 user_id 에 해당하는 subtitle_settings 를 업데이트한다.
+    S3 read-modify-write 패턴 (기존 deduct_credits 와 동일).
+    성공 시 True, 사용자 미발견 시 False.
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        user_found = False
+        for user in users:
+            if user["id"] == user_id:
+                user["subtitle_settings"] = settings
+                user_found = True
+                break
+
+        if not user_found:
+            logger.warning(f"[subtitle_settings] SAVE user={user_id} — 사용자 없음")
+            return False
+
+        _s3.put_object(
+            Bucket=BUCKET_USERS,
+            Key=KEY_USERS,
+            Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+        )
+        logger.info(f"[subtitle_settings] SAVE user={user_id} 완료")
+        return True
+    except Exception as e:
+        logger.error(f"[subtitle_settings] SAVE 실패 user={user_id}: {e}")
+        raise
+
+
+# ─────────────────────────────────────────────
+# Creatomate modifications 주입 헬퍼
+# ─────────────────────────────────────────────
+
+def apply_subtitle_settings_to_variables(
+    variables: dict,
+    subtitle_settings: Optional[dict],
+) -> None:
+    """
+    subtitle_settings 를 Creatomate modifications dict (variables) 에 주입.
+    subtitle_settings 가 None/비어있으면 아무것도 주입 안 함 (기존 동작 유지).
+
+    api-contract.md "BE 처리 로직 — Creatomate modifications 주입" 구현.
+    변수는 in-place 수정.
+    """
+    if not subtitle_settings:
+        return
+
+    ts = subtitle_settings.get("title") or {}
+    ss = subtitle_settings.get("subtitle") or {}
+
+    # 제목(title element)
+    if ts.get("font_family"):
+        variables["title.font_family"] = ts["font_family"]
+    if ts.get("fill_color"):
+        variables["title.fill_color"] = ts["fill_color"]
+    title_size_vmin = SIZE_MAP_TITLE_VMIN.get(ts.get("font_size", "M"))
+    if title_size_vmin:  # M 이면 None → 미주입 (auto-fit 유지)
+        variables["title.font_size"] = title_size_vmin
+
+    # 자막(Subtitles-* × 5 — 모두 동일 설정)
+    sub_font = ss.get("font_family") or DEFAULT_SUBTITLE_SETTINGS["font_family"]
+    sub_size = SIZE_MAP_SUBTITLE_VMIN.get(
+        ss.get("font_size", "M"), "6 vmin"
+    )
+    sub_color = ss.get("fill_color") or DEFAULT_SUBTITLE_SETTINGS["fill_color"]
+
+    for suffix in SUBTITLE_SUFFIXES:
+        variables[f"Subtitles-{suffix}.font_family"] = sub_font
+        variables[f"Subtitles-{suffix}.font_size"] = sub_size
+        variables[f"Subtitles-{suffix}.fill_color"] = sub_color

--- a/auto_video_create_server/tests/test_cycle3_subtitle.py
+++ b/auto_video_create_server/tests/test_cycle3_subtitle.py
@@ -1,0 +1,284 @@
+"""
+test_cycle3_subtitle.py — cycle-3 자막 스타일 단위 테스트
+
+외부 의존성(S3, Google Fonts API, Creatomate) 없이 순수 로직만 검증.
+pytest 없이 stdlib unittest 사용 (서버 환경 최소 의존).
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+# 서버 루트를 sys.path 에 추가
+_SERVER_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SERVER_ROOT not in sys.path:
+    sys.path.insert(0, _SERVER_ROOT)
+
+
+# ─────────────────────────────────────────────
+# font_service 테스트
+# ─────────────────────────────────────────────
+
+class TestFontService(unittest.TestCase):
+
+    def test_build_slug_basic(self):
+        """폰트 이름 → slug 변환 규칙 검증."""
+        from services.font_service import _build_slug
+        self.assertEqual(_build_slug("Noto Sans KR"), "noto-sans-kr")
+        self.assertEqual(_build_slug("Black Han Sans"), "black-han-sans")
+        self.assertEqual(_build_slug("Do Hyeon"), "do-hyeon")
+        self.assertEqual(_build_slug("Nanum Gothic"), "nanum-gothic")
+
+    def test_fallback_fonts_structure(self):
+        """fallback 목록 구조 검증 — family/category/slug 모두 있어야 함."""
+        from services.font_service import FALLBACK_FONTS
+        self.assertGreater(len(FALLBACK_FONTS), 0)
+        for font in FALLBACK_FONTS:
+            self.assertIn("family", font, f"family 없음: {font}")
+            self.assertIn("category", font, f"category 없음: {font}")
+            self.assertIn("slug", font, f"slug 없음: {font}")
+            self.assertIsInstance(font["family"], str)
+            self.assertIsInstance(font["category"], str)
+            self.assertIsInstance(font["slug"], str)
+
+    def test_get_korean_fonts_fallback_on_missing_key(self):
+        """GOOGLE_FONTS_API_KEY 없을 때 fallback 반환."""
+        # lru_cache 초기화 필요
+        from services import font_service
+        font_service._fetch_korean_fonts_cached.cache_clear()
+
+        with patch.dict(os.environ, {}, clear=True):
+            # GOOGLE_FONTS_API_KEY 제거
+            os.environ.pop("GOOGLE_FONTS_API_KEY", None)
+            fonts = font_service.get_korean_fonts()
+            self.assertIsInstance(fonts, list)
+            self.assertGreater(len(fonts), 0)
+            # fallback 의 첫 번째 항목 확인 (알파벳순: Black Han Sans)
+            families = [f["family"] for f in fonts]
+            self.assertIn("Black Han Sans", families)
+
+        # 캐시 다시 초기화 (다른 테스트에 영향 없도록)
+        font_service._fetch_korean_fonts_cached.cache_clear()
+
+    def test_get_allowed_font_families_returns_set(self):
+        """get_allowed_font_families 가 set 을 반환하는지 확인."""
+        from services import font_service
+        font_service._fetch_korean_fonts_cached.cache_clear()
+        os.environ.pop("GOOGLE_FONTS_API_KEY", None)
+        families = font_service.get_allowed_font_families()
+        self.assertIsInstance(families, set)
+        self.assertIn("Noto Sans KR", families)
+        font_service._fetch_korean_fonts_cached.cache_clear()
+
+
+# ─────────────────────────────────────────────
+# subtitle_settings_service 테스트
+# ─────────────────────────────────────────────
+
+class TestValidateSubtitleSettings(unittest.TestCase):
+
+    def _make_valid_settings(self):
+        return {
+            "title": {
+                "font_family": "Black Han Sans",
+                "font_size": "M",
+                "fill_color": "#fff100",
+            },
+            "subtitle": {
+                "font_family": "Noto Sans KR",
+                "font_size": "M",
+                "fill_color": "#ffffff",
+            },
+        }
+
+    def test_valid_settings_no_errors(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        allowed = {"Black Han Sans", "Noto Sans KR"}
+        errors = validate_subtitle_settings(settings, allowed)
+        self.assertEqual(errors, [])
+
+    def test_invalid_font_size(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["title"]["font_size"] = "XL"
+        errors = validate_subtitle_settings(settings, {"Black Han Sans", "Noto Sans KR"})
+        self.assertTrue(any("font_size" in e for e in errors))
+
+    def test_invalid_hex_color(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["subtitle"]["fill_color"] = "red"  # 유효하지 않은 hex
+        errors = validate_subtitle_settings(settings, {"Black Han Sans", "Noto Sans KR"})
+        self.assertTrue(any("fill_color" in e for e in errors))
+
+    def test_invalid_font_family_not_in_allowed(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["title"]["font_family"] = "Comic Sans"  # 한글 지원 아님
+        allowed = {"Black Han Sans", "Noto Sans KR"}
+        errors = validate_subtitle_settings(settings, allowed)
+        self.assertTrue(any("font_family" in e for e in errors))
+
+    def test_empty_allowed_families_skips_font_check(self):
+        """Google Fonts API 장애 시 허용 목록 비어있으면 font_family 검증 완화."""
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["title"]["font_family"] = "AnyFont"
+        errors = validate_subtitle_settings(settings, set())  # 빈 set
+        self.assertEqual(errors, [])
+
+    def test_missing_subtitle_section(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = {"title": self._make_valid_settings()["title"]}  # subtitle 누락
+        errors = validate_subtitle_settings(settings, {"Black Han Sans"})
+        self.assertTrue(any("subtitle" in e for e in errors))
+
+    def test_hex_color_lowercase_valid(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["subtitle"]["fill_color"] = "#ff0000"
+        errors = validate_subtitle_settings(settings, {"Black Han Sans", "Noto Sans KR"})
+        self.assertEqual(errors, [])
+
+    def test_hex_color_uppercase_valid(self):
+        from services.subtitle_settings_service import validate_subtitle_settings
+        settings = self._make_valid_settings()
+        settings["subtitle"]["fill_color"] = "#FF0000"
+        errors = validate_subtitle_settings(settings, {"Black Han Sans", "Noto Sans KR"})
+        self.assertEqual(errors, [])
+
+
+class TestApplySubtitleSettingsToVariables(unittest.TestCase):
+
+    def test_none_settings_does_nothing(self):
+        """subtitle_settings=None 이면 variables 변경 없음."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, None)
+        self.assertEqual(variables, {})
+
+    def test_empty_settings_does_nothing(self):
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, {})
+        self.assertEqual(variables, {})
+
+    def test_full_settings_injects_all(self):
+        """완전한 설정값 → title + 5개 subtitle 모두 주입."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        settings = {
+            "title": {
+                "font_family": "Black Han Sans",
+                "font_size": "L",
+                "fill_color": "#fff100",
+            },
+            "subtitle": {
+                "font_family": "Noto Sans KR",
+                "font_size": "S",
+                "fill_color": "#ffffff",
+            },
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+
+        # 제목 검증
+        self.assertEqual(variables["title.font_family"], "Black Han Sans")
+        self.assertEqual(variables["title.fill_color"], "#fff100")
+        self.assertEqual(variables["title.font_size"], "12 vmin")  # L
+
+        # 자막 5개 검증
+        for suffix in SUBTITLE_SUFFIXES:
+            self.assertEqual(variables[f"Subtitles-{suffix}.font_family"], "Noto Sans KR")
+            self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "4 vmin")   # S
+            self.assertEqual(variables[f"Subtitles-{suffix}.fill_color"], "#ffffff")
+
+    def test_title_size_M_not_injected(self):
+        """제목 font_size=M 이면 title.font_size 미주입 (auto-fit 유지)."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        settings = {
+            "title": {
+                "font_family": "Black Han Sans",
+                "font_size": "M",
+                "fill_color": "#fff100",
+            },
+            "subtitle": {
+                "font_family": "Noto Sans KR",
+                "font_size": "M",
+                "fill_color": "#ffffff",
+            },
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+        self.assertNotIn("title.font_size", variables)
+
+    def test_subtitle_size_M_is_6vmin(self):
+        """자막 font_size=M → 6 vmin (기존 템플릿 기본값과 동일)."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        settings = {
+            "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+        for suffix in SUBTITLE_SUFFIXES:
+            self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "6 vmin")
+
+    def test_subtitle_size_L_is_8vmin(self):
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        settings = {
+            "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "L", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+        for suffix in SUBTITLE_SUFFIXES:
+            self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "8 vmin")
+
+    def test_5_subtitle_elements_all_set(self):
+        """자막 element 정확히 5개(6K5/JTM/MDV/5Z2/D6M) 모두 키 생성."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        settings = {
+            "title": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+        self.assertEqual(len(SUBTITLE_SUFFIXES), 5)
+        for suffix in SUBTITLE_SUFFIXES:
+            self.assertIn(f"Subtitles-{suffix}.font_family", variables)
+            self.assertIn(f"Subtitles-{suffix}.font_size", variables)
+            self.assertIn(f"Subtitles-{suffix}.fill_color", variables)
+
+    def test_existing_variables_not_overwritten_by_none_settings(self):
+        """settings=None 이면 기존 variables 그대로 유지."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        variables = {"image1.source": "https://example.com/img.jpg"}
+        apply_subtitle_settings_to_variables(variables, None)
+        self.assertIn("image1.source", variables)
+
+
+class TestSubtitleSuffixes(unittest.TestCase):
+    def test_suffix_list_exact(self):
+        """SUBTITLE_SUFFIXES 가 정확히 architecture.md DEP-01 확인값과 일치."""
+        from services.subtitle_settings_service import SUBTITLE_SUFFIXES
+        self.assertEqual(SUBTITLE_SUFFIXES, ["6K5", "JTM", "MDV", "5Z2", "D6M"])
+
+
+class TestSizeMapConstants(unittest.TestCase):
+    def test_size_map_subtitle_vmin(self):
+        from services.subtitle_settings_service import SIZE_MAP_SUBTITLE_VMIN
+        self.assertEqual(SIZE_MAP_SUBTITLE_VMIN["S"], "4 vmin")
+        self.assertEqual(SIZE_MAP_SUBTITLE_VMIN["M"], "6 vmin")
+        self.assertEqual(SIZE_MAP_SUBTITLE_VMIN["L"], "8 vmin")
+
+    def test_size_map_title_vmin(self):
+        from services.subtitle_settings_service import SIZE_MAP_TITLE_VMIN
+        self.assertEqual(SIZE_MAP_TITLE_VMIN["S"], "6 vmin")
+        self.assertIsNone(SIZE_MAP_TITLE_VMIN["M"])   # auto-fit → None
+        self.assertEqual(SIZE_MAP_TITLE_VMIN["L"], "12 vmin")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -110,7 +110,12 @@ resource "aws_lambda_function" "fastapi" {
   environment {
     variables = {
       ENV = "production"
-      # 필요한 환경변수 추가
+      # cycle-3: 한글 폰트 목록 조회용 Google Fonts Developer API 키.
+      # 실제 값은 infra/terraform.tfvars (gitignore) 또는 GitHub Secrets → terraform plan -var 로 주입.
+      # PO 운영 작업: Google Cloud Console에서 키 발급 후 아래 두 곳에 등록 필요.
+      #   1) infra/terraform.tfvars: google_fonts_api_key = "AIza..."
+      #   2) GitHub Secrets: GOOGLE_FONTS_API_KEY (terraform.yml 의 -var 플래그로 전달)
+      GOOGLE_FONTS_API_KEY = var.google_fonts_api_key
     }
   }
   timeout     = 30
@@ -157,6 +162,16 @@ output "api_endpoint" {
 variable "github_token" {
   description = "GitHub Personal Access Token for Amplify"
   type        = string
+}
+
+# cycle-3: Google Fonts Developer API 키 (한글 폰트 목록 조회).
+# 실값은 infra/terraform.tfvars (gitignore) 또는 GitHub Secrets 로 주입.
+# 발급: https://console.cloud.google.com → API 및 서비스 → 사용자 인증 정보 → API 키 생성
+#       → Web Fonts 제한 권장.
+variable "google_fonts_api_key" {
+  description = "Google Fonts Developer API Key for Korean font subset listing (GET /api/blog/fonts)"
+  type        = string
+  sensitive   = true
 }
 
 resource "aws_amplify_app" "frontend" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -116,6 +116,15 @@ resource "aws_lambda_function" "fastapi" {
       #   1) infra/terraform.tfvars: google_fonts_api_key = "AIza..."
       #   2) GitHub Secrets: GOOGLE_FONTS_API_KEY (terraform.yml 의 -var 플래그로 전달)
       GOOGLE_FONTS_API_KEY = var.google_fonts_api_key
+      # security-hotfix (cycle-3, 2026-06-01): OPENAI_API_KEY 를 terraform 관리로 이관.
+      # 배경: 이전에는 AWS 콘솔에서 수동 등록돼 있어 terraform plan 이 AWS 상태 refresh 시
+      #        해당 키 실값을 "삭제 예정" diff 로 평문 출력 → PR 코멘트로 공개 노출됨 (PR #40, #45).
+      # 해결: terraform 이 키를 var 로 알면 plan 이 drift 없이 인식 → 평문 실값 diff 미발생.
+      # 실제 값은 아래 중 하나로 주입 (실값 커밋 절대 금지):
+      #   1) infra/terraform.tfvars (gitignore): openai_api_key = "sk-..."
+      #   2) GitHub Secrets: OPENAI_API_KEY → terraform.yml 의 -var="openai_api_key=$OPENAI_API_KEY" 로 전달
+      # PO 운영 작업: 유출된 키 2개 폐기+재발급 후 GitHub Secrets + AWS Lambda(test/prod) 에 새 키 등록.
+      OPENAI_API_KEY = var.openai_api_key
     }
   }
   timeout     = 30
@@ -170,6 +179,20 @@ variable "github_token" {
 #       → Web Fonts 제한 권장.
 variable "google_fonts_api_key" {
   description = "Google Fonts Developer API Key for Korean font subset listing (GET /api/blog/fonts)"
+  type        = string
+  sensitive   = true
+}
+
+# security-hotfix (cycle-3, 2026-06-01): OPENAI_API_KEY terraform 관리 이관.
+# 배경: AWS 콘솔 수동 등록 → terraform plan refresh 시 실값 평문 노출 (PR #40, #45).
+# 실값은 infra/terraform.tfvars (gitignore) 또는 GitHub Secrets 로 주입 (실값 커밋 금지).
+# PO 운영 작업:
+#   1) OpenAI 대시보드에서 유출 키 2개 폐기 + 새 키 발급 (OpenAI 가 이미 1개 비활성화함 — 나머지 1개도 즉시 폐기)
+#   2) 새 키를 GitHub Secrets OPENAI_API_KEY 에 등록
+#   3) AWS Lambda my-fastapi-backend (test/prod) 콘솔에서 OPENAI_API_KEY 환경변수 업데이트
+#   4) GitHub secret scanning 알림 2건 resolve
+variable "openai_api_key" {
+  description = "OpenAI API Key for video script generation and DALL-E background generation"
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
## 사이클 범위 (cycle-3)

select step 에 **자막 스타일(폰트 / 크기 / 색상) 편집 기능** 추가. 데스크탑 전용.

- 편집 대상: **제목(title)** + **자막(subtitle)** 2개 텍스트, 각각 폰트/크기/색 = 6설정
- 기본 접힘(collapsed) 영역, 펼치면 좌 6컨트롤 / 우 9:16 CSS 미리보기 (좌우분할)
- 접힌 헤더에 현재 설정 미니 샘플 칩 2개 노출
- 폰트: **한글 글리프 보유 폰트만** 검색형 모달 picker 로 노출 (Google Fonts `?subset=korean` 자동 필터)
- 색: 자유 컬러피커, 제목/자막 독립. 기본 제목 `#fff100` / 자막 `#ffffff`
- 미리보기: CSS 시뮬레이션 (Creatomate 렌더 호출 없음)
- 설정 저장: 계정(user_id) 단위, S3 users.json 확장. 진입 시 BE 에서 GET 으로 로드 (프론트 로컬 저장 없음)

## 디자인 산출물 요약

- brief: `agents/outputs/design/01-brief.md`
- flow: `03-flow.md` / IA: `04-ia.md` / visual: `05-visual.md` / copy: `06-copy.md`
- wireframe: `07-wireframe.html` (인터랙티브 — 모달 picker / 접힘 / 미리보기 시연)

## architect ADR 핵심 (DEP 해소)

- **DEP-01**: Creatomate 템플릿 element 구조 실사 확인 완료. 제목=`title`(기본 `#fff100`), 자막=`Subtitles-*` 5개 element. font_family/font_size/fill_color modifications 오버라이드 전부 가능.
- **DEP-02**: 한글 필터 = Google Fonts API `?subset=korean` 자동. 카테고리는 `category` 필드 매핑.
- **DEP-03**: vmin↔S/M/L 매핑 확정 (자막 S4/M6/L8 vmin, 제목 S6/M auto/L12 vmin)
- **DEP-04**: users.json 확장 (별도 파일 X)
- **DEP-05/06**: `GET/PUT /api/blog/subtitle-settings` + `GET /api/blog/fonts` + generate-video 에 subtitle_settings 추가

## 변경 인벤토리

- [ ] **infra**: `GOOGLE_FONTS_API_KEY` 환경변수 (Lambda env / GitHub Secrets)
- [ ] **backend**: `GET/PUT /api/blog/subtitle-settings`, `GET /api/blog/fonts`, create_creatomate_video modifications 확장(제목+자막5), users.json 스키마 확장
- [ ] **frontend**: 편집 영역(접힘/미니칩/좌우분할), FontPickerModal(가상스크롤), 크기 세그먼트, 컬러피커, 9:16 미리보기, 설정 GET/PUT 연동

## 배포 전 마이그레이션 체크리스트

- [ ] `GOOGLE_FONTS_API_KEY` 발급 + test/prod Lambda env 등록
- [ ] users.json 기존 레코드에 subtitle_settings 기본값 backfill 여부 확인 (없으면 런타임 기본값 fallback)
- [ ] Creatomate test/prod 템플릿 element 이름 동일성 확인

## Test plan

(QA 단계에서 채워짐 — C-0 static / C-1 runtime / C-2 PO 직접)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
