### PR TITLE
fix(cycle-3.1): BUG-013 — subtitle-settings 저장 500 hotfix

### DIFF
--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -9,7 +9,6 @@ data-model.md §1~§3 스키마 준수.
 
 import json
 import logging
-import os
 import re
 from typing import Optional
 
@@ -55,12 +54,7 @@ DEFAULT_SUBTITLE_SETTINGS: dict = {
     "fill_color": "#ffffff",
 }
 
-_s3 = boto3.client(
-    "s3",
-    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-    region_name="ap-northeast-2",
-)
+_s3 = boto3.client("s3", region_name="ap-northeast-2")
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## 버그
`PUT /api/blog/subtitle-settings` 가 test 환경 Lambda 에서 유효한 요청도 항상 500 반환. FE 는 debounce 저장 실패를 조용히 삼켜 사용자는 "저장됐어요" 로 인지하지만 실제로는 미저장 (silent data loss).

리포트: `agents/outputs/qa/bug-reports/BUG-013-subtitle-settings-save-500-invalid-credentials.md`

## 원인
`auto_video_create_server/services/subtitle_settings_service.py` 모듈 레벨 `_s3` 클라이언트가 `boto3.client("s3", aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"), aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"), ...)` 로 자격증명을 명시 전달. Lambda 환경변수엔 해당 키가 없어 `None` 이 전달되고, boto3 는 이 경우 IAM Role 자동 폴백을 쓰지 않아 `InvalidAccessKeyId` 발생. 같은 파일이 GET 경로에 쓰는 `utils/s3_utils.py::load_json_from_s3()` 는 인자 없는 `boto3.client("s3")` 라서 GET 만 정상 동작했음.

## 수정
`_s3 = boto3.client("s3", region_name="ap-northeast-2")` 로 변경 (인자 없이 IAM Role 위임). `utils/s3_utils.py` 패턴과 통일 — backend-review W-03 도 함께 해소. 그 외 로직 변경 없음.

## 검증
- `python3 -m py_compile services/subtitle_settings_service.py` 통과
- `pytest tests/test_cycle3_subtitle.py` 23 passed
- 배포 후 재검증 필요: PUT → 200 → GET round-trip (BUG-013 재현 테스트 제안 항목)

## Test plan
- [ ] main 머지 후 test Lambda 자동 배포 확인
- [ ] `PUT /api/blog/subtitle-settings` 유효 요청 → 200 확인
- [ ] 곧바로 `GET /api/blog/subtitle-settings` → 저장값 반영 확인 (persist round-trip)
- [ ] CloudWatch 로그에 InvalidAccessKeyId 재발 없음 확인