### PR TITLE
fix(cycle-3.2): BUG-014 — 1번 자막 색상 미반영 hotfix

### DIFF
--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -200,3 +200,4 @@ def apply_subtitle_settings_to_variables(
         variables[f"Subtitles-{suffix}.font_family"] = sub_font
         variables[f"Subtitles-{suffix}.font_size"] = sub_size
         variables[f"Subtitles-{suffix}.fill_color"] = sub_color
+        variables[f"Subtitles-{suffix}.transcript_color"] = sub_color

--- a/auto_video_create_server/tests/test_cycle3_subtitle.py
+++ b/auto_video_create_server/tests/test_cycle3_subtitle.py
@@ -193,6 +193,9 @@ class TestApplySubtitleSettingsToVariables(unittest.TestCase):
             self.assertEqual(variables[f"Subtitles-{suffix}.font_family"], "Noto Sans KR")
             self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "4 vmin")   # S
             self.assertEqual(variables[f"Subtitles-{suffix}.fill_color"], "#ffffff")
+            # BUG-014: 템플릿 Subtitles-6K5 에 transcript_color 가 명시돼 있어 fill_color 를 무시함.
+            # transcript_color 도 동일값으로 함께 주입해야 comp1 자막 색이 반영됨.
+            self.assertEqual(variables[f"Subtitles-{suffix}.transcript_color"], "#ffffff")
 
     def test_title_size_M_not_injected(self):
         """제목 font_size=M 이면 title.font_size 미주입 (auto-fit 유지)."""
@@ -250,6 +253,7 @@ class TestApplySubtitleSettingsToVariables(unittest.TestCase):
             self.assertIn(f"Subtitles-{suffix}.font_family", variables)
             self.assertIn(f"Subtitles-{suffix}.font_size", variables)
             self.assertIn(f"Subtitles-{suffix}.fill_color", variables)
+            self.assertIn(f"Subtitles-{suffix}.transcript_color", variables)
 
     def test_existing_variables_not_overwritten_by_none_settings(self):
         """settings=None 이면 기존 variables 그대로 유지."""


### PR DESCRIPTION
## 버그
- 증상: 자막 색 변경 시 2~5번 컴포지션 자막은 바뀌는데 1번 자막(comp1)만 항상 흰색.
- 원인: 템플릿의 `Subtitles-6K5`(composition_1) 요소에만 `transcript_color: rgba(255,255,255,1)` 이 명시 설정돼 있음. Creatomate transcript(자동자막) 요소는 `transcript_color` 가 설정되면 `fill_color` 를 무시하고 그 색으로 강제함. test/prod 템플릿 둘 다 동일.

## 수정
`apply_subtitle_settings_to_variables` 의 자막 주입 루프에 `transcript_color` 를 `fill_color` 와 동일값으로 함께 주입.
(미설정 요소에 줘도 동일색이라 무해 — 5개 element 모두 안전하게 적용)

## 테스트
- `pytest tests/test_cycle3_subtitle.py` 23 passed
- 기존 주입 테스트(`test_full_settings_injects_all`, `test_5_subtitle_elements_all_set`)에 transcript_color assert 추가

## 관련
- BUG-014: agents/outputs/qa/bug-reports/BUG-014-comp1-subtitle-transcript-color-override.md