### PR TITLE
feat(sprint-4): 컨셉 영상 샘플 4종 + 가변 장면 수 (WIP)

### DIFF
--- a/auto_video_create_front/src/app/components/SampleCard.tsx
+++ b/auto_video_create_front/src/app/components/SampleCard.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
+
+// sprint-4: 컨셉 영상 샘플 4종. BE 응답(GET /api/blog/concept-samples) 스키마 — api-contract.md 확정
+export interface ConceptSample {
+  concept_sample_id: string;
+  name: string;
+  is_default: boolean;
+  scene_count: number;
+  hero_still_url: string | null;
+  sample_video_url: string | null;
+}
+
+// 05-visual.md §4.2 팔레트(방향값) — 실제 결과물 색이 아니라 "카드 4장 구분용" placeholder.
+// hero_still_url 확보 후에는 이 색조 자체가 폐기 대상(§0-1).
+const SAMPLE_GRADIENTS: Record<string, string> = {
+  sample_1: "linear-gradient(135deg, #90A4C0 0%, #64789C 100%)", // Cool Slate (기본)
+  sample_2: "linear-gradient(135deg, #F0B268 0%, #D98A3D 100%)", // Warm Amber
+  sample_3: "linear-gradient(135deg, #8FBF9F 0%, #5E9E76 100%)", // Sage Green
+  sample_4: "linear-gradient(135deg, #B08FC7 0%, #8B63A8 100%)", // Muted Violet
+};
+const FALLBACK_GRADIENT = "linear-gradient(135deg, #c8d2e0 0%, #a9b4c6 100%)";
+
+interface SampleCardProps {
+  sample: ConceptSample;
+  selected: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+  onViewVideo: () => void;
+}
+
+export default function SampleCard({ sample, selected, disabled, onSelect, onViewVideo }: SampleCardProps) {
+  const gradient = SAMPLE_GRADIENTS[sample.concept_sample_id] ?? FALLBACK_GRADIENT;
+
+  const handleSelectKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onSelect();
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        width: 124,
+        flexShrink: 0,
+        border: selected ? "2px solid #1976d2" : "1.5px solid #e3e6ef",
+        borderRadius: "10px",
+        p: 1,
+        bgcolor: selected ? "rgba(25, 118, 210, 0.06)" : "#fff",
+        position: "relative",
+        textAlign: "center",
+        opacity: disabled ? 0.5 : 1,
+        transition: "border-color 0.15s, background-color 0.15s",
+      }}
+    >
+      {selected && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: -7,
+            left: -7,
+            width: 18,
+            height: 18,
+            borderRadius: "50%",
+            bgcolor: "#1976d2",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 2,
+          }}
+        >
+          <CheckIcon sx={{ fontSize: 12 }} />
+        </Box>
+      )}
+
+      {/* 선택 hit-area — 대표 스틸 (05-visual.md §1.1 "대") */}
+      <Box
+        role="radio"
+        aria-checked={selected}
+        aria-label={`${sample.name}, ${sample.scene_count}장면 선택`}
+        tabIndex={disabled ? -1 : 0}
+        onClick={disabled ? undefined : onSelect}
+        onKeyDown={handleSelectKeyDown}
+        sx={{
+          width: 96,
+          height: 170,
+          borderRadius: "6px",
+          margin: "0 auto",
+          position: "relative",
+          overflow: "hidden",
+          cursor: disabled ? "default" : "pointer",
+          outline: "none",
+          "&:hover": disabled ? {} : { boxShadow: "0 0 0 2px rgba(25,118,210,0.35)" },
+          "&:focus-visible": { boxShadow: "0 0 0 2px #1976d2" },
+        }}
+      >
+        {sample.hero_still_url ? (
+          <Box
+            component="img"
+            src={sample.hero_still_url}
+            alt={`${sample.name} 대표 장면`}
+            sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+          />
+        ) : (
+          <>
+            <Box sx={{ position: "absolute", inset: 0, background: gradient }} aria-hidden="true" />
+            <Typography
+              sx={{
+                position: "absolute",
+                bottom: 4,
+                left: 0,
+                width: "100%",
+                textAlign: "center",
+                fontSize: 8,
+                color: "rgba(255,255,255,0.85)",
+                letterSpacing: 0.3,
+              }}
+            >
+              {sample.name} placeholder
+            </Typography>
+          </>
+        )}
+      </Box>
+
+      <Typography sx={{ fontSize: 12, fontWeight: 700, mt: 1 }}>{sample.name}</Typography>
+      <Box
+        sx={{
+          display: "inline-block",
+          fontSize: 10,
+          color: "#888",
+          bgcolor: "#f0f4f8",
+          borderRadius: 999,
+          px: 1,
+          py: "1px",
+          mt: 0.5,
+        }}
+      >
+        {sample.scene_count}장면
+      </Box>
+
+      {/* 조회(view) hit-area — 선택 hit-area와 물리적으로 분리(구분선 + ≥32px 밴드) */}
+      <Box sx={{ mt: 1, pt: 0.75, borderTop: "1px dashed #e3e6ef" }}>
+        <Box
+          component="button"
+          type="button"
+          disabled={disabled}
+          onClick={(e) => {
+            e.stopPropagation();
+            onViewVideo();
+          }}
+          aria-label={`${sample.name} 영상 보기`}
+          sx={{
+            display: "block",
+            width: "100%",
+            minHeight: 32,
+            fontSize: 11,
+            fontWeight: 600,
+            color: "#1976d2",
+            bgcolor: "#eaf2fc",
+            border: "1px solid #bcdcf7",
+            borderRadius: "6px",
+            py: 0.5,
+            cursor: disabled ? "default" : "pointer",
+            fontFamily: "inherit",
+            "&:hover": disabled ? {} : { bgcolor: "#dcebfa" },
+          }}
+        >
+          영상 보기
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/auto_video_create_front/src/app/components/SampleDetailModal.tsx
+++ b/auto_video_create_front/src/app/components/SampleDetailModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Box, Dialog, IconButton, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import { ConceptSample } from "./SampleCard";
+
+interface SampleDetailModalProps {
+  sample: ConceptSample | null;
+  onClose: () => void;
+}
+
+// 04-ia.md §4 / 05-visual.md §1.2 — input SampleCard "영상 보기" 버튼 전용 트리거.
+// select 단계에는 이 모달을 여는 수단이 없다(D9/D10, 04-ia.md).
+// X / ESC / 배경클릭 전부 동일하게 모달만 닫고, 선택 상태(concept_sample_id)는 절대 변경하지 않는다.
+export default function SampleDetailModal({ sample, onClose }: SampleDetailModalProps) {
+  const open = !!sample;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      aria-label={sample ? `${sample.name} 영상 보기` : undefined}
+      PaperProps={{
+        sx: { bgcolor: "transparent", boxShadow: "none", borderRadius: 0, m: 0 },
+      }}
+      BackdropProps={{
+        sx: { bgcolor: "rgba(0,0,0,0.55)" },
+      }}
+    >
+      {sample && (
+        <Box
+          sx={{
+            width: 240,
+            height: 427,
+            bgcolor: "#0a0a0a",
+            borderRadius: "16px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            position: "relative",
+            boxShadow: "0 16px 40px rgba(0,0,0,0.5)",
+            overflow: "hidden",
+          }}
+        >
+          <IconButton
+            onClick={onClose}
+            aria-label="닫기"
+            size="small"
+            sx={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              color: "rgba(255,255,255,0.55)",
+              zIndex: 2,
+              "&:hover": { color: "rgba(255,255,255,0.85)" },
+            }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+
+          {sample.sample_video_url ? (
+            <video
+              src={sample.sample_video_url}
+              controls
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+          ) : (
+            <>
+              <Box
+                aria-hidden="true"
+                sx={{
+                  width: 56,
+                  height: 56,
+                  borderRadius: "50%",
+                  border: "2px solid rgba(255,255,255,0.25)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "rgba(255,255,255,0.3)",
+                }}
+              >
+                <PlayArrowIcon sx={{ fontSize: 26 }} />
+              </Box>
+              <Typography sx={{ mt: 2, color: "rgba(255,255,255,0.5)", fontSize: 12 }}>
+                샘플 영상 준비 중입니다
+              </Typography>
+            </>
+          )}
+        </Box>
+      )}
+    </Dialog>
+  );
+}

--- a/auto_video_create_front/src/app/components/SampleSelector.tsx
+++ b/auto_video_create_front/src/app/components/SampleSelector.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import SampleCard, { ConceptSample } from "./SampleCard";
+
+interface SampleSelectorProps {
+  samples: ConceptSample[];
+  selectedId: string;
+  disabled?: boolean;
+  onSelect: (conceptSampleId: string) => void;
+  onViewVideo: (sample: ConceptSample) => void;
+}
+
+// 04-ia.md §3 — "컨셉 샘플" 카드 4장, radiogroup, 샘플1 pre-selected.
+// 목록이 아직 로드되지 않았으면 렌더링하지 않음(input 화면은 카드 없이도 기존과 동일하게 동작 — "무시하는 유저" 경로 A).
+export default function SampleSelector({ samples, selectedId, disabled, onSelect, onViewVideo }: SampleSelectorProps) {
+  if (samples.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 2.75 }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 1, mb: 1.25 }}>
+        <Typography sx={{ fontSize: 13, fontWeight: 700 }}>컨셉 샘플</Typography>
+        <Box
+          sx={{
+            fontSize: 10,
+            color: "#888",
+            bgcolor: "#f0f4f8",
+            border: "1px solid #e3e6ef",
+            borderRadius: 999,
+            px: 1,
+            py: "2px",
+            fontWeight: 500,
+          }}
+        >
+          선택 사항
+        </Box>
+      </Box>
+      <Typography sx={{ fontSize: 12, color: "#888", mb: 1.5 }}>
+        영상 보기로 미리 확인할 수 있어요
+      </Typography>
+      <Box
+        role="radiogroup"
+        aria-label="컨셉 샘플 선택 (선택 사항)"
+        sx={{ display: "flex", flexWrap: "nowrap", gap: 1.5, justifyContent: "center" }}
+      >
+        {samples.map((sample) => (
+          <SampleCard
+            key={sample.concept_sample_id}
+            sample={sample}
+            selected={sample.concept_sample_id === selectedId}
+            disabled={disabled}
+            onSelect={() => onSelect(sample.concept_sample_id)}
+            onViewVideo={() => onViewVideo(sample)}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -12,6 +12,9 @@ import EditIcon from '@mui/icons-material/Edit';
 import AuthGuard from "../components/AuthGuard";
 import LogoutButton from "../components/LogoutButton";
 import SubtitleStyleEditor, { SubtitleSettings } from "./components/SubtitleStyleEditor";
+import SampleSelector from "./components/SampleSelector";
+import SampleDetailModal from "./components/SampleDetailModal";
+import { ConceptSample } from "./components/SampleCard";
 
 interface MediaList {
   images: string[];
@@ -63,8 +66,13 @@ export default function Home() {
   const isPc = useMediaQuery(theme.breakpoints.up('md'));
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
-  // sectionMedia: 길이 5, 각 원소는 SectionMedia 또는 null
-  const [sectionMedia, setSectionMedia] = useState<(SectionMedia|null)[]>([null, null, null, null, null]);
+  // sprint-4: 컨셉 영상 샘플 4종 — concept_sample_id 는 input에서 확정되면 select 내내 고정(04-ia.md D9)
+  const [conceptSampleId, setConceptSampleId] = useState<string>("sample_1");
+  const [sampleList, setSampleList] = useState<ConceptSample[]>([]);
+  const [detailModalSample, setDetailModalSample] = useState<ConceptSample | null>(null);
+
+  // sectionMedia: 길이는 항상 현재 샘플의 scene_count(N)와 동일, 각 원소는 SectionMedia 또는 null
+  const [sectionMedia, setSectionMedia] = useState<(SectionMedia|null)[]>([]);
 
   // GPT가 생성한 스크립트 수정 상태 (수정 중인 카드 인덱스 + 임시 텍스트)
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
@@ -80,6 +88,25 @@ export default function Home() {
     if (typeof window !== "undefined") {
       setIsLoggedIn(!!localStorage.getItem("user_id"));
     }
+  }, []);
+
+  // sprint-4: 컨셉 샘플 목록 마운트 시 1회 조회 (재요청 없음 — api-contract.md FE 사용 시점)
+  useEffect(() => {
+    const loadSamples = async () => {
+      try {
+        const res = await authFetch(`${API_BASE_URL}/api/blog/concept-samples`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.status === "success" && Array.isArray(data.samples)) {
+          setSampleList(data.samples);
+          const defaultSample = data.samples.find((s: ConceptSample) => s.is_default);
+          if (defaultSample) setConceptSampleId(defaultSample.concept_sample_id);
+        }
+      } catch {
+        // 조회 실패 시 SampleSelector 는 렌더링하지 않고, concept_sample_id 는 기본값 'sample_1'로 진행
+      }
+    };
+    loadSamples();
   }, []);
 
   // 미디어 클릭 핸들러
@@ -163,7 +190,7 @@ export default function Home() {
     setStep('input');
     setVideoUrl(null);
     setGenerateError(null);
-    setSectionMedia([null, null, null, null, null]);
+    setSectionMedia([]);
     setEditingIdx(null);
     setEditingText("");
     const controller = new AbortController();
@@ -172,7 +199,7 @@ export default function Home() {
       const res = await authFetch(`${API_BASE_URL}/api/blog/extract-all`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ blog_url: blogUrl }),
+        body: JSON.stringify({ blog_url: blogUrl, concept_sample_id: conceptSampleId }),
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
@@ -181,18 +208,20 @@ export default function Home() {
         setMedia({ images: data.images, videos: data.videos, scripts: data.scripts, title: data.title });
         setScripts((data.scripts || []).map((s: { script: string } | string) => typeof s === 'string' ? s : s.script));
         setTitle(data.title || "");
-        // cycle-2: BE 가 default_slot_count 만큼 부족 슬롯을 알려주면 후반부를 AI 기본 배경으로 채움
+        // sprint-4: 슬롯 배열 길이는 항상 현재 샘플의 scene_count(N) 기준 — 하드코딩 5 제거
+        const sceneCount: number = typeof data.scene_count === 'number' && data.scene_count > 0
+          ? data.scene_count
+          : (Array.isArray(data.scripts) ? data.scripts.length : 0);
+        const initialSectionMedia: (SectionMedia | null)[] = Array(sceneCount).fill(null);
+        // cycle-2: BE 가 default_slot_count 만큼 부족 슬롯을 알려주면 후반부를 AI 기본 배경으로 채움 (N 기준)
         const defaultCount: number = typeof data.default_slot_count === 'number' ? data.default_slot_count : 0;
-        if (defaultCount > 0) {
-          setSectionMedia(prev => {
-            const updated = [...prev];
-            const start = Math.max(0, 5 - defaultCount);
-            for (let i = start; i < 5; i++) {
-              updated[i] = { type: 'default', url: null, isDefaultBackground: true };
-            }
-            return updated;
-          });
+        if (defaultCount > 0 && sceneCount > 0) {
+          const start = Math.max(0, sceneCount - defaultCount);
+          for (let i = start; i < sceneCount; i++) {
+            initialSectionMedia[i] = { type: 'default', url: null, isDefaultBackground: true };
+          }
         }
+        setSectionMedia(initialSectionMedia);
         setStep('select');
       } else {
         setError(data.message || "이미지/영상/스크립트 추출에 실패했습니다.");
@@ -220,6 +249,7 @@ export default function Home() {
           scripts,
           sections: sectionMedia,
           subtitle_settings: subtitleSettings,
+          concept_sample_id: conceptSampleId,
         }),
         signal: controller.signal,
       });
@@ -273,9 +303,10 @@ export default function Home() {
     setStep('input');
     setVideoUrl(null);
     setGenerateError(null);
-    setSectionMedia([null, null, null, null, null]);
+    setSectionMedia([]);
     setEditingIdx(null);
     setEditingText("");
+    // sprint-4 D3: concept_sample_id 는 세션 내 유지 — 여기서 초기화하지 않는다.
   };
 
   const handleBetaAlert = (msg: string) => {
@@ -348,7 +379,7 @@ export default function Home() {
         {/* 메인 컨텐츠 */}
         <Box sx={{ flex: 1, minHeight: '100vh', display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "flex-start", px: 2 }}>
           {step === 'input' && (
-            <Box sx={{ width: "100%", maxWidth: 420, textAlign: "center", mt: 12 }}>
+            <Box sx={{ width: "100%", maxWidth: 560, textAlign: "center", mt: 12 }}>
               <Typography variant="h4" fontWeight={700} gutterBottom sx={{ mt: 6 }}>
                 내 블로그로 숏폼 영상 만들기
               </Typography>
@@ -366,6 +397,13 @@ export default function Home() {
                   sx={{ mb: 2, bgcolor: "#fafbfc" }}
                   inputProps={{ inputMode: "url" }}
                   InputLabelProps={{ shrink: true }}
+                />
+                <SampleSelector
+                  samples={sampleList}
+                  selectedId={conceptSampleId}
+                  disabled={loading}
+                  onSelect={setConceptSampleId}
+                  onViewVideo={(sample) => setDetailModalSample(sample)}
                 />
                 <Button type="submit" variant="contained" color="primary" fullWidth size="large" disabled={loading} sx={{ fontWeight: 700, fontSize: 18, height: 48 }}>
                   {loading ? <CircularProgress size={24} color="inherit" /> : "숏폼 만들기"}
@@ -420,12 +458,20 @@ export default function Home() {
                       size="large"
                       sx={{ fontWeight: 700, minWidth: 140 }}
                       onClick={handleGenerateVideo}
-                      disabled={sectionMedia.filter(m => m !== null).length !== 5 || loading || editingIdx !== null || !title.trim() || scripts.some(s => !s.trim())}
+                      disabled={sectionMedia.filter(m => m !== null).length !== scripts.length || loading || editingIdx !== null || !title.trim() || scripts.some(s => !s.trim())}
                     >
                       {loading ? <CircularProgress size={24} color="inherit" /> : "숏폼 만들기"}
                     </Button>
                   </Box>
                 </Box>
+                {/* sprint-4: generate-video 실패(예: concept_sample_template_not_configured) 에러 배너 — api-contract.md FE 연동 흐름 */}
+                {generateError && (
+                  <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4 }}>
+                    <Alert severity="error" sx={{ mb: 2 }} onClose={() => setGenerateError(null)}>
+                      {generateError}
+                    </Alert>
+                  </Box>
+                )}
                 {/* cycle-3: 자막 스타일 설정 (Row 1 — 접힘 기본) */}
                 <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
                   <SubtitleStyleEditor onSettingsChange={setSubtitleSettings} />
@@ -434,7 +480,7 @@ export default function Home() {
                     variant="body2"
                     sx={{ color: '#666', mb: 2, fontSize: 13 }}
                   >
-                    이미지를 선택해 주세요 — 5개를 모두 고르면 영상 생성하기가 활성화됩니다.
+                    이미지를 선택해 주세요 — {scripts.length}개를 모두 고르면 숏폼 만들기가 활성화돼요
                   </Typography>
                 </Box>
                 <Box sx={{ flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'flex-start', gap: 4, px: 4, py: 2, maxWidth: 1200, mx: 'auto', width: '100%' }}>
@@ -815,7 +861,7 @@ export default function Home() {
                   fullWidth
                   size="large"
                   sx={{ mt: 3, mb: 2 }}
-                  disabled={sectionMedia.filter(m => m !== null).length !== 5 || loading || editingIdx !== null || !title.trim() || scripts.some(s => !s.trim())}
+                  disabled={sectionMedia.filter(m => m !== null).length !== scripts.length || loading || editingIdx !== null || !title.trim() || scripts.some(s => !s.trim())}
                   onClick={handleGenerateVideo}
                 >
                   최종 영상 생성하기
@@ -893,6 +939,9 @@ export default function Home() {
             </Box>
           )}
         </Dialog>
+
+        {/* sprint-4: 컨셉 샘플 상세 모달 — input SampleCard "영상 보기" 전용 */}
+        <SampleDetailModal sample={detailModalSample} onClose={() => setDetailModalSample(null)} />
       </Box>
     </AuthGuard>
   );

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -15,6 +15,8 @@ from services.subtitle_settings_service import (
     validate_subtitle_settings,
     apply_subtitle_settings_to_variables,
 )
+# sprint-4: 컨셉 영상 샘플 4종 (B-2, architecture.md §2-1/data-model.md §1)
+from services.concept_samples import get_sample, list_samples_public
 from crawler.dispatcher import UnsupportedPlatformError
 from utils.s3_utils import load_json_from_s3
 import os
@@ -133,6 +135,9 @@ router = APIRouter()
 
 class ExtractMediaRequest(BaseModel):
     blog_url: str
+    # sprint-4 (B-2): optional — 없거나 미인식 값이면 BE 가 sample_1(기본값)로 폴백
+    # (api-contract.md "미선택 통과 허용" 원칙, 절대 400 에러로 막지 않음)
+    concept_sample_id: Optional[str] = None
 
 class ExtractMediaResponse(BaseModel):
     status: str
@@ -142,6 +147,9 @@ class ExtractMediaResponse(BaseModel):
     category: Optional[Literal["restaurant", "general"]] = None
     platform: Optional[Literal["naver", "tistory", "brunch"]] = None
     default_slot_count: Optional[int] = 0
+    # sprint-4 (B-2): concept_sample_id echo(폴백 적용된 값) + scene_count(N)
+    concept_sample_id: Optional[str] = None
+    scene_count: Optional[int] = None
     message: str = None
 
 
@@ -154,6 +162,22 @@ class SectionMedia(BaseModel):
 @router.get("/hello")
 def hello():
     return {"message": "Hello, World!!!!!"}
+
+
+@router.get("/concept-samples")
+def get_concept_samples(user=Depends(require_active_subscription)):
+    """
+    GET /api/blog/concept-samples
+
+    input 단계 SampleSelector(카드 4장) + SampleDetailModal(영상 보기) 렌더에 필요한
+    데이터를 단일 응답으로 제공 (목록 + "상세" 통합, 별도 상세 API 없음).
+    api-contract.md "신규 엔드포인트: 컨셉 샘플 목록 조회" 구현.
+
+    BE 내부 전용 필드(creatomate_template_id, subtitle_element_suffixes, hook_prompt)는
+    응답에 포함하지 않는다 — list_samples_public() 이 필터링.
+    """
+    return {"status": "success", "samples": list_samples_public()}
+
 
 @router.post("/extract-all")
 def extract_all(req: ExtractMediaRequest, user=Depends(require_active_subscription)):
@@ -169,7 +193,9 @@ def extract_all(req: ExtractMediaRequest, user=Depends(require_active_subscripti
                 "message": "등록된 블로그 주소가 아닙니다. 관리자에게 문의해주세요.",
             }
 
-        result = get_blog_media_and_scripts(req.blog_url)
+        # sprint-4 (B-2): concept_sample_id → scene_count(N)/hook_prompt 는
+        # get_blog_media_and_scripts 내부에서 concept_samples.get_sample() 로 조회.
+        result = get_blog_media_and_scripts(req.blog_url, concept_sample_id=req.concept_sample_id)
         print("extract_all 성공")
         return {"status": "success", **result}
     except UnsupportedPlatformError as e:
@@ -215,9 +241,11 @@ class SubtitleSettingsRequest(BaseModel):
 class GenerateVideoRequest(BaseModel):
     title: str
     scripts: List[str]
-    sections: List[SectionMedia]  # 5개
+    sections: List[SectionMedia]  # sprint-4: 길이 = N(고정 아님), scene_count 만큼
     # cycle-3: optional — 없으면 Creatomate 템플릿 기본값 유지
     subtitle_settings: Optional[SubtitleSettingsModel] = None
+    # sprint-4 (B-2): optional — 없거나 미인식 값이면 sample_1(기본값) 폴백 (extract-all과 동일 방어 정책)
+    concept_sample_id: Optional[str] = None
 
 class GenerateVideoResponse(BaseModel):
     status: str
@@ -238,8 +266,9 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
             voice_id=SUPERTONE_VOICE_ID,
             speed=SUPERTONE_SPEED
         )
-        audio_local_paths = audio_local_paths[:5]
-        audio_urls = audio_urls[:5]
+        # sprint-4 (B-2): 하드코딩 [:5] 제거 — scripts 길이(N)만큼만 사용
+        audio_local_paths = audio_local_paths[:len(req.scripts)]
+        audio_urls = audio_urls[:len(req.scripts)]
 
         # 3. 섹션별 미디어 타입에 따라 Creatomate 변수 생성
         # cycle-2: type='default' 슬롯은 AI 배경을 lazy 병렬 생성 (ADR-4).
@@ -278,11 +307,17 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
                 variables[f"image{i}.visible"] = "true"
                 variables[f"video{i}.visible"] = "false"
 
+        # sprint-4 (B-2): concept_sample_id → 샘플 조회 (미인식/None 이면 sample_1 폴백)
+        sample = get_sample(req.concept_sample_id)
+
         # 4. cycle-3: subtitle_settings 가 있으면 Creatomate modifications 에 주입
+        # sprint-4: subtitle_element_suffixes 는 샘플별 룩업 (None 이면 자막 주입 스킵,
+        # 템플릿 기본값 유지 — architecture.md §4-4)
         if req.subtitle_settings:
             apply_subtitle_settings_to_variables(
                 variables,
                 req.subtitle_settings.model_dump(),
+                sample.get("subtitle_element_suffixes"),
             )
             print(
                 f"[generate_video] subtitle_settings 주입 완료 "
@@ -294,17 +329,22 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
         result = create_creatomate_video(
             audio_paths=audio_urls,
             scripts=req.scripts,
+            concept_sample_id=sample["concept_sample_id"],
             title=req.title,
             user_id=user["id"],  # 크레딧 체크/차감을 위해 user_id 전달
             **variables
         )
         # Creatomate 응답 처리
         if isinstance(result, dict) and result.get("error"):
-            # 크레딧 부족 등의 에러 응답
+            # 크레딧 부족 / concept_sample_template_not_configured 등의 에러 응답.
+            # sprint-4: api-contract.md 는 "error_code" 키를 요구 — 기존 FE 호환을 위해
+            # error_type 도 동일 값으로 함께 반환한다.
+            error_code = result.get("error")
             return {
-                "status": "error", 
+                "status": "error",
+                "error_code": error_code,
                 "message": result.get("message", "영상 생성 실패"),
-                "error_type": result.get("error")
+                "error_type": error_code,
             }
         
         # Creatomate 응답에서 render_id 추출

--- a/auto_video_create_server/services/blog_shorts.py
+++ b/auto_video_create_server/services/blog_shorts.py
@@ -4,22 +4,42 @@ cycle-2 갱신:
 - crawler.dispatcher 로 멀티 플랫폼 분기 (네이버 / 티스토리 / 브런치)
 - services.classifier 로 맛집 vs 일반 자동 분류
 - summarize 에 category 전달 → 카테고리별 프롬프트 분기
-- default_slot_count 계산 (이미지 + 영상 < 5 일 때)
+- default_slot_count 계산 (이미지 + 영상 < N 일 때)
+
+sprint-4 갱신 (B-2, architecture.md §F-4):
+- concept_sample_id 파라미터 수신 → concept_samples.get_sample() 로 scene_count(N)/hook_prompt 조회
+- category(classifier.py, 맛집/일반) × concept_sample(scene_count/hook_prompt) 두 축을
+  동시에 summarize_for_shorts_sets() 로 전달 — 두 축은 직교(orthogonal)하며 서로 무관
+- default_slot_count 계산 기준을 고정 5 → scene_count(N) 로 전환
 """
+from typing import Optional
+
 from crawler.dispatcher import extract as dispatcher_extract
 from crawler.dispatcher import UnsupportedPlatformError  # noqa: F401  (re-export)
 from crawler.naver import extract_blog_content  # noqa: F401  (backward-compat re-export)
 from .summarize import summarize_for_shorts_sets
 from .classifier import classify_blog
+from .concept_samples import get_sample
 
 
-def get_blog_media_and_scripts(blog_url: str) -> dict:
-    """블로그 URL 1개 → 추출 + 분류 + 스크립트 생성 + 슬롯 부족 카운트."""
+def get_blog_media_and_scripts(blog_url: str, concept_sample_id: Optional[str] = None) -> dict:
+    """블로그 URL 1개 → 추출 + 분류 + 스크립트 생성 + 슬롯 부족 카운트.
+
+    concept_sample_id: 미인식/None 이면 concept_samples.get_sample() 이 sample_1(기본값)로
+    폴백한다 (api-contract.md "미선택 통과 허용" 원칙).
+    """
     text, images, videos, platform = dispatcher_extract(blog_url)
     category = classify_blog(text)
-    title, scripts = summarize_for_shorts_sets(text, category=category)
-    # 5개 슬롯 중 이미지+영상으로 채워지지 않는 슬롯 수
-    default_slot_count = max(0, 5 - (len(images) + len(videos)))
+    sample = get_sample(concept_sample_id)
+    scene_count = sample["scene_count"]
+    title, scripts = summarize_for_shorts_sets(
+        text,
+        category=category,
+        scene_count=scene_count,
+        hook_prompt=sample["hook_prompt"],
+    )
+    # N개 슬롯 중 이미지+영상으로 채워지지 않는 슬롯 수
+    default_slot_count = max(0, scene_count - (len(images) + len(videos)))
     return {
         "text": text,
         "images": images,
@@ -29,4 +49,6 @@ def get_blog_media_and_scripts(blog_url: str) -> dict:
         "category": category,
         "platform": platform,
         "default_slot_count": default_slot_count,
+        "concept_sample_id": sample["concept_sample_id"],
+        "scene_count": scene_count,
     }

--- a/auto_video_create_server/services/concept_samples.py
+++ b/auto_video_create_server/services/concept_samples.py
@@ -1,0 +1,140 @@
+"""
+concept_samples.py — sprint-4 신규
+
+컨셉 영상 샘플 4종의 정의. concept_sample_id 를 키로 하는 단일 소스.
+- extract-all: scene_count, hook_prompt 사용
+- generate-video: creatomate_template_id, subtitle_element_suffixes 사용
+- GET /api/blog/concept-samples: name, is_default, scene_count, hero_still_url,
+  sample_video_url 만 공개(list_samples_public())
+
+★ 전 필드 placeholder. 실제 값은 PO 자산 확보 후 갱신(architecture.md DEP-S4-01/05/06).
+
+저장 위치는 코드 상수로 확정(PO 2026-07-28, architecture.md §2-1 / data-model.md §1).
+S3 JSON 안(B)은 기각됐으나, 향후 전환 니즈 대비 아래 함수(get_sample / list_samples_public /
+get_template_id) 시그니처는 저장 위치와 무관하게 재사용 가능하도록 설계돼 있다 — 전환 비용은
+이 파일 내부 구현 교체로 한정된다.
+
+★ 릴리즈 게이트(architecture.md §5, 비협상): creatomate_template_id 가 전부 None(placeholder)인
+상태로는 prod 배포 금지. 최소 sample_1(기본값)의 실 template_id 확보 전까지 prod 릴리즈 불가.
+"""
+
+from typing import Optional, TypedDict
+
+
+class TemplateIdByEnv(TypedDict):
+    test: Optional[str]
+    production: Optional[str]
+
+
+class ConceptSample(TypedDict):
+    concept_sample_id: str
+    name: str
+    is_default: bool
+    scene_count: int
+    hero_still_url: Optional[str]
+    sample_video_url: Optional[str]
+    hook_prompt: str
+    creatomate_template_id: TemplateIdByEnv
+    subtitle_element_suffixes: Optional[list[str]]
+
+
+DEFAULT_SAMPLE_ID = "sample_1"
+
+SAMPLE_DEFINITIONS: dict[str, ConceptSample] = {
+    "sample_1": {
+        "concept_sample_id": "sample_1",
+        "name": "컨셉 1",
+        "is_default": True,
+        "scene_count": 4,
+        "hero_still_url": None,
+        "sample_video_url": None,
+        "hook_prompt": (
+            # placeholder — 02-insight.md §3-2 "밝은(감탄/텐션형)" 계열 임시 배정.
+            # 실제 4종 확정 후 샘플별로 재배정 필요.
+            "감탄사·리액션을 결론보다 먼저 배치하는 감탄/텐션형 훅을 1문장, "
+            "15자 내외로 작성해줘. 예: '여기 진짜 미쳤어요, 보자마자 감탄함'"
+        ),
+        "creatomate_template_id": {"test": None, "production": None},
+        "subtitle_element_suffixes": None,
+    },
+    "sample_2": {
+        "concept_sample_id": "sample_2",
+        "name": "컨셉 2",
+        "is_default": False,
+        "scene_count": 6,
+        "hero_still_url": None,
+        "sample_video_url": None,
+        "hook_prompt": (
+            # placeholder — "차분한(공감/스토리형)" 계열 임시 배정.
+            "청자의 상황 공감이나 잔잔한 질문으로 시작하는 공감/스토리형 훅을 1문장, "
+            "15자 내외로 작성해줘. 예: '퇴근하고 지친 날, 자꾸 생각나는 곳'"
+        ),
+        "creatomate_template_id": {"test": None, "production": None},
+        "subtitle_element_suffixes": None,
+    },
+    "sample_3": {
+        "concept_sample_id": "sample_3",
+        "name": "컨셉 3",
+        "is_default": False,
+        "scene_count": 5,
+        "hero_still_url": None,
+        "sample_video_url": None,
+        "hook_prompt": (
+            # placeholder — "역동적(충격/속도형)" 계열 임시 배정.
+            "단언·수치·반전 등으로 시작하는 충격/속도형 훅을 1문장, 15자 내외로 "
+            "작성해줘. 과장 표현 없이 사실 기반으로. 예: '웨이팅 2시간. 그래도 갑니다'"
+        ),
+        "creatomate_template_id": {"test": None, "production": None},
+        "subtitle_element_suffixes": None,
+    },
+    "sample_4": {
+        "concept_sample_id": "sample_4",
+        "name": "컨셉 4",
+        "is_default": False,
+        "scene_count": 4,
+        "hero_still_url": None,
+        "sample_video_url": None,
+        "hook_prompt": (
+            # placeholder — 4번째 계열 임시(정보형). PO 확정 시 실제 컨셉으로 교체.
+            "핵심 정보를 담백하게 제시하며 시작하는 훅을 1문장, 15자 내외로 "
+            "작성해줘. 과장 없이 사실 위주로."
+        ),
+        "creatomate_template_id": {"test": None, "production": None},
+        "subtitle_element_suffixes": None,
+    },
+}
+
+
+def get_sample(concept_sample_id: Optional[str]) -> ConceptSample:
+    """concept_sample_id 로 샘플 조회. 없거나 미인식 값이면 기본 샘플로 폴백."""
+    return SAMPLE_DEFINITIONS.get(concept_sample_id) or SAMPLE_DEFINITIONS[DEFAULT_SAMPLE_ID]
+
+
+def list_samples_public() -> list[dict]:
+    """GET /api/blog/concept-samples 응답용 — BE 내부 전용 필드 제외.
+
+    제외 필드(api-contract.md): creatomate_template_id, subtitle_element_suffixes, hook_prompt
+    """
+    return [
+        {
+            "concept_sample_id": s["concept_sample_id"],
+            "name": s["name"],
+            "is_default": s["is_default"],
+            "scene_count": s["scene_count"],
+            "hero_still_url": s["hero_still_url"],
+            "sample_video_url": s["sample_video_url"],
+        }
+        for s in SAMPLE_DEFINITIONS.values()
+    ]
+
+
+def get_template_id(concept_sample_id: Optional[str], env: Optional[str]) -> Optional[str]:
+    """concept_sample_id + ENV → Creatomate template_id. 미확보 시 None."""
+    sample = get_sample(concept_sample_id)
+    env_key = "production" if (env or "").lower() == "production" else "test"
+    return sample["creatomate_template_id"].get(env_key)
+
+
+def get_scene_count(concept_sample_id: Optional[str]) -> int:
+    """concept_sample_id → scene_count(N). extract-all/blog_shorts 에서 사용."""
+    return get_sample(concept_sample_id)["scene_count"]

--- a/auto_video_create_server/services/create_creatomate_video.py
+++ b/auto_video_create_server/services/create_creatomate_video.py
@@ -4,21 +4,30 @@ import json
 import time
 from dotenv import load_dotenv
 from .account_service import check_user_credits, deduct_credits, get_current_credits
+from .concept_samples import get_template_id
 
 load_dotenv()
 
 CREATOMATE_API_KEY = os.environ["CREATOMATE_API_KEY"]
-if os.environ.get("ENV") == "production":
-    CREATOMATE_TEMPLATE_ID = "cab85e50-1e78-41b8-9644-80a061d349f6"
-else:
-    CREATOMATE_TEMPLATE_ID = "eda9d421-b086-4660-9f3c-9236d826226f"
+
+# sprint-4 (B-2): 모듈 레벨 CREATOMATE_TEMPLATE_ID(단일, 폐기된 기존 프로덕션 템플릿) 상수는
+# 완전히 제거됐다 — 더 이상 어떤 샘플도 이 ID 를 참조하지 않는다(data-model.md §3).
+# template_id 는 이제 concept_sample_id 기준으로 concept_samples.get_template_id() 룩업.
 
 ## 네이버 "e78f211a-9e4c-4f5c-a871-36b9d680ee11"
 ## 유튜브 "14457245-7822-48a6-a711-62d15b739b85"
 
-def create_creatomate_video(audio_paths, scripts, title=None, output_path="creatomate_result.mp4", video5=None, user_id=None, **kwargs):
+def create_creatomate_video(
+    audio_paths,
+    scripts,
+    concept_sample_id=None,
+    title=None,
+    output_path="creatomate_result.mp4",
+    user_id=None,
+    **kwargs,
+):
     print("create_creatomate_video 호출")
-    
+
     # 크레딧 체크 (1000 크레딧 필요)
     if user_id:
         if not check_user_credits(user_id, 1000):
@@ -29,21 +38,25 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
                 "current_credits": current_credits,
                 "required_credits": 1000
             }
-    
-    variables = {
-        "audio1.source": audio_paths[0],
-        "audio2.source": audio_paths[1],
-        "audio3.source": audio_paths[2],
-        "audio4.source": audio_paths[3],
-        "audio5.source": audio_paths[4],
-    }
-    if video5:
-        variables["video5.source"] = video5
+
+    # sprint-4 (B-2, architecture.md §4-2): concept_sample_id → template_id 룩업.
+    # placeholder(None) 상태면 Creatomate 를 호출하지 않고 명확한 에러로 안내(방어적 설계) —
+    # "확보 전엔 죽는" 게 아니라 "확보 전엔 안내 메시지로 막는다".
+    template_id = get_template_id(concept_sample_id, env=os.environ.get("ENV"))
+    if not template_id:
+        return {
+            "error": "concept_sample_template_not_configured",
+            "message": "선택한 컨셉의 템플릿이 아직 준비되지 않았어요. 다른 컨셉을 선택해 주세요.",
+        }
+
+    # sprint-4 (B-2): audio1~audio5 하드코딩 dict 리터럴 → N(=len(audio_paths)) 가변 처리.
+    scene_count = len(audio_paths)
+    variables = {f"audio{i + 1}.source": audio_paths[i] for i in range(scene_count)}
     if title:
         variables["title.text"] = title
     variables.update(kwargs)
     payload = {
-        "template_id": CREATOMATE_TEMPLATE_ID,
+        "template_id": template_id,
         "modifications": variables
     }
     
@@ -86,20 +99,27 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
             "message": f"영상 생성 API 호출 실패: {str(e)}"
         }
 
-def get_creatomate_vars(durations):
+def get_creatomate_vars(durations, scene_count):
+    """scene_count(N) 기반 composition_1~N + composition_title/logo 타이밍 계산.
+
+    sprint-4 (B-2, architecture.md §4-3/data-model.md §4): N-일반화. 현재 /api/blog/generate-video
+    라이브 경로에서는 호출되지 않는다(F-2 — 기존 단일 템플릿이 Creatomate 자동 타이밍에 의존).
+    신규 템플릿 4종이 자동 타이밍을 지원하지 않을 경우에만 연결 검토 대상(DEP-S4-01/06 실사 후 판단).
+    호출부(scripts/pipeline_blog_to_shorts.py, 오프라인 전용)는 시그니처 변경으로 별도 갱신 필요.
+    """
     print("get_creatomate_vars 호출")
     creatomate_vars = {}
-    for i in range(5):
+    for i in range(scene_count):
         creatomate_vars[f"composition_{i+1}.duration"] = durations[i] if i < len(durations) and durations[i] is not None else 0
     times = [0]
-    for i in range(1, 5):
+    for i in range(1, scene_count):
         prev_time = times[-1] + (durations[i-1] if i-1 < len(durations) and durations[i-1] is not None else 0)
         times.append(prev_time)
-    for i in range(5):
+    for i in range(scene_count):
         creatomate_vars[f"composition_{i+1}.time"] = times[i]
-    comp5_time = creatomate_vars["composition_5.time"]
-    comp5_duration = creatomate_vars["composition_5.duration"]
-    total_duration = comp5_time + comp5_duration
+    last_time = creatomate_vars[f"composition_{scene_count}.time"]
+    last_duration = creatomate_vars[f"composition_{scene_count}.duration"]
+    total_duration = last_time + last_duration
     creatomate_vars["composition_title.time"] = 0
     creatomate_vars["composition_title.duration"] = total_duration
     creatomate_vars["composition_logo.time"] = 0

--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -39,8 +39,12 @@ SIZE_MAP_TITLE_VMIN: dict[str, Optional[str]] = {
     "L": "12 vmin",
 }
 
-# Creatomate 자막 element 식별자 (data-model.md §6 / architecture.md DEP-01)
-SUBTITLE_SUFFIXES = ["6K5", "JTM", "MDV", "5Z2", "D6M"]
+# sprint-4 (B-2, data-model.md §3): 모듈 레벨 SUBTITLE_SUFFIXES 상수(기존 단일 템플릿 전용,
+# ["6K5","JTM","MDV","5Z2","D6M"])는 폐기됐다. 자막 element 식별자는 이제 템플릿(=concept_sample)
+# 마다 다르므로 concept_samples.get_sample(id)["subtitle_element_suffixes"] 로 샘플별 룩업한다.
+# apply_subtitle_settings_to_variables() 의 subtitle_element_suffixes 인자로 전달받는다.
+# 값은 DEP-S4-06(신규 템플릿 4종 실사) 완료 전까지 전부 None — 이 기간 동안 자막 스타일
+# 커스터마이징은 조용히 비활성화되고 Creatomate 템플릿 기본값이 유지된다(에러 아님).
 
 # 기본값 (data-model.md §3)
 DEFAULT_TITLE_SETTINGS: dict = {
@@ -166,6 +170,7 @@ def save_subtitle_settings(user_id: str, settings: dict) -> bool:
 def apply_subtitle_settings_to_variables(
     variables: dict,
     subtitle_settings: Optional[dict],
+    subtitle_element_suffixes: Optional[list[str]] = None,
 ) -> None:
     """
     subtitle_settings 를 Creatomate modifications dict (variables) 에 주입.
@@ -173,6 +178,12 @@ def apply_subtitle_settings_to_variables(
 
     api-contract.md "BE 처리 로직 — Creatomate modifications 주입" 구현.
     변수는 in-place 수정.
+
+    sprint-4 (B-2, architecture.md §4-4): subtitle_element_suffixes 는 호출부(api/blog.py)가
+    concept_samples.get_sample(concept_sample_id)["subtitle_element_suffixes"] 로 전달한다.
+    title element 는 suffix 와 무관(이름이 항상 "title")하므로 항상 적용하고, 자막
+    (Subtitles-{suffix}.*) 주입은 subtitle_element_suffixes 가 비어있거나 None(DEP-S4-06
+    미해소 샘플)이면 조용히 건너뛰어 Creatomate 템플릿 기본값을 유지한다(에러 아님).
     """
     if not subtitle_settings:
         return
@@ -180,7 +191,7 @@ def apply_subtitle_settings_to_variables(
     ts = subtitle_settings.get("title") or {}
     ss = subtitle_settings.get("subtitle") or {}
 
-    # 제목(title element)
+    # 제목(title element) — suffix 와 무관, subtitle_settings 가 있으면 항상 적용
     if ts.get("font_family"):
         variables["title.font_family"] = ts["font_family"]
     if ts.get("fill_color"):
@@ -189,14 +200,17 @@ def apply_subtitle_settings_to_variables(
     if title_size_vmin:  # M 이면 None → 미주입 (auto-fit 유지)
         variables["title.font_size"] = title_size_vmin
 
-    # 자막(Subtitles-* × 5 — 모두 동일 설정)
+    # 자막(Subtitles-* × N — 모두 동일 설정). suffix 목록 미확보 시 스킵.
+    if not subtitle_element_suffixes:
+        return
+
     sub_font = ss.get("font_family") or DEFAULT_SUBTITLE_SETTINGS["font_family"]
     sub_size = SIZE_MAP_SUBTITLE_VMIN.get(
         ss.get("font_size", "M"), "6 vmin"
     )
     sub_color = ss.get("fill_color") or DEFAULT_SUBTITLE_SETTINGS["fill_color"]
 
-    for suffix in SUBTITLE_SUFFIXES:
+    for suffix in subtitle_element_suffixes:
         variables[f"Subtitles-{suffix}.font_family"] = sub_font
         variables[f"Subtitles-{suffix}.font_size"] = sub_size
         variables[f"Subtitles-{suffix}.fill_color"] = sub_color

--- a/auto_video_create_server/services/summarize.py
+++ b/auto_video_create_server/services/summarize.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import anthropic
 from dotenv import load_dotenv
@@ -9,6 +10,8 @@ load_dotenv()
 CLAUDE_MODEL = "claude-sonnet-5"
 
 # 구조화 출력 스키마 — Claude 가 항상 이 형태의 JSON 만 반환하도록 강제
+# sprint-4: scripts 배열 길이는 더 이상 고정 5가 아니라 scene_count(N)로 가변.
+# build_shorts_output_schema() 가 요청마다 minItems/maxItems 를 주입한다.
 SHORTS_OUTPUT_SCHEMA = {
     "type": "object",
     "properties": {
@@ -27,6 +30,19 @@ SHORTS_OUTPUT_SCHEMA = {
     "additionalProperties": False,
 }
 
+
+def build_shorts_output_schema(scene_count: int) -> dict:
+    """SHORTS_OUTPUT_SCHEMA 에 scene_count(N) 기준 minItems/maxItems 를 주입한 스키마 반환.
+
+    architecture.md §3-3 — Claude structured output 경로에서만 개수를 스키마로 강제 가능.
+    OpenAI fallback 경로는 구조화 출력을 쓰지 않아 이 스키마가 적용되지 않는다(§3-3 비대칭, 문서화됨).
+    """
+    schema = copy.deepcopy(SHORTS_OUTPUT_SCHEMA)
+    schema["properties"]["scripts"]["minItems"] = scene_count
+    schema["properties"]["scripts"]["maxItems"] = scene_count
+    return schema
+
+
 def extract_json_from_codeblock(content):
     match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", content)
     if match:
@@ -41,16 +57,23 @@ def fix_json_keys(json_str):
 # cycle-2: 카테고리별 프롬프트 분기 (ADR-3 / architecture.md).
 # - restaurant: 기존 맛집 프롬프트 (역/동 + 상호명, 메뉴/가격, 위트)
 # - general: 일반 블로그용 generic 프롬프트 (핵심 키워드 + 본문 핵심, 위트 유지)
+#
+# sprint-4: category(맛집/일반) 축과 concept_sample(scene_count/hook_prompt) 축은 직교
+# (architecture.md F-4) — 두 프롬프트 분기가 {scene_count}/{hook_prompt} 로 동시 적용된다.
 RESTAURANT_PROMPT = """
 아래 블로그 글을 바탕으로, 유튜브 쇼츠 영상에 어울리는 제목과 스크립트를 자동으로 만들어줘.
 
 타이틀 : '무슨무슨역 상호명' 또는 '무슨무슨동 상호명' 형식으로 생성해줘. (예: '교대역 스키당', '압구정동 저스트스테이크')
 타이틀은 블로그 본문에서 역/동/상호명을 추출해서 만들어줘. 만약 역/동 정보가 없으면 상호명만 사용해줘.
 
+- 훅(첫 문장) 작성 지침:
+{hook_prompt}
+
 - 스크립트 작성 Tip :
-첫번째 스크립트는 제일 강렬하게 어필해서 이목을 끌 수 있게 하면 좋아.
+첫번째 스크립트는 위 훅 지침을 참고해서 제일 강렬하게 이목을 끌 수 있게 작성해줘.
 메뉴에 대한 가격과 설명이 들어가면 좋아
 마지막 스크립트는 마무리하는 말투로 작성해줘.
+그 사이 스크립트들은 본문 핵심 내용 위주로.
 
 - 주의 사항 :
 줄바꿈이 필요한 부분은 반드시 \\n(역슬래시+n)으로 표기해줘. 실제 엔터(줄바꿈)는 사용하지 마.
@@ -60,10 +83,10 @@ RESTAURANT_PROMPT = """
 
 - 출력 형식
 아래는 예시이고, 반드시 예시와 같이 JSON 객체 형태로 반환해줘. 설명이나 코드블록 없이 JSON만 반환해줘.
-**scripts 배열은 반드시 5개만 포함해야 하며, 5개보다 많거나 적으면 안 돼. 6개 이상, 4개 이하로 반환하면 안 되고, 반드시 5개만 반환해야 해. 예시와 개수가 다르면 잘못된 응답이야.**
-**scripts 배열의 원소 개수는 반드시 5개여야 하며, 5개가 아니면 잘못된 응답이야. 반드시 예시와 개수, 구조가 일치해야 해.**
+**scripts 배열은 반드시 {scene_count}개만 포함해야 하며, {scene_count}개보다 많거나 적으면 안 돼. 예시는 형식 참고용일 뿐이고, 실제 개수는 반드시 {scene_count}개여야 해.**
+**scripts 배열의 원소 개수는 반드시 {scene_count}개여야 하며, {scene_count}개가 아니면 잘못된 응답이야.**
 
-예시:
+예시(형식 참고용, 실제 개수는 위 지침을 따를 것):
 {{
   "title": "교대역 스키당",
   "scripts": [
@@ -87,9 +110,12 @@ GENERAL_PROMPT = """
 타이틀 : 본문의 핵심 키워드 1~2개로 짧고 명확하게 만들어줘. 한국어 일반 톤.
    예: "양양 서핑 후기", "VS Code 단축키 꿀팁", "초보를 위한 코딩 입문", "강릉 1박2일 여행"
 
+- 훅(첫 문장) 작성 지침:
+{hook_prompt}
+
 - 스크립트 작성 Tip :
-첫번째 스크립트는 가장 강렬한 한 마디로 시작해서 이목을 끌어야 해.
-중간 3개는 본문의 핵심 정보 또는 인상 깊은 포인트 위주로.
+첫번째 스크립트는 위 훅 지침을 참고해서 가장 강렬한 한 마디로 시작해서 이목을 끌어야 해.
+중간 스크립트들은 본문의 핵심 정보 또는 인상 깊은 포인트 위주로.
 마지막 스크립트는 깔끔하게 마무리하는 말투로.
 
 - 주의 사항 :
@@ -101,9 +127,10 @@ GENERAL_PROMPT = """
 
 - 출력 형식
 아래는 예시이고, 반드시 예시와 같이 JSON 객체 형태로 반환해줘. 설명이나 코드블록 없이 JSON만 반환해줘.
-**scripts 배열은 반드시 5개만 포함해야 하며, 5개보다 많거나 적으면 안 돼. 6개 이상, 4개 이하로 반환하면 안 되고, 반드시 5개만 반환해야 해. 예시와 개수가 다르면 잘못된 응답이야.**
+**scripts 배열은 반드시 {scene_count}개만 포함해야 하며, {scene_count}개보다 많거나 적으면 안 돼. 예시는 형식 참고용일 뿐이고, 실제 개수는 반드시 {scene_count}개여야 해.**
+**scripts 배열의 원소 개수는 반드시 {scene_count}개여야 하며, {scene_count}개가 아니면 잘못된 응답이야.**
 
-예시:
+예시(형식 참고용, 실제 개수는 위 지침을 따를 것):
 {{
   "title": "양양 서핑 후기",
   "scripts": [
@@ -121,8 +148,11 @@ GENERAL_PROMPT = """
 """
 
 
-def _generate_with_claude(prompt):
-    """Claude Sonnet 으로 title+scripts JSON 텍스트 생성. refusal 시 None."""
+def _generate_with_claude(prompt, schema):
+    """Claude Sonnet 으로 title+scripts JSON 텍스트 생성. refusal 시 None.
+
+    schema: build_shorts_output_schema(scene_count) 로 생성된 scene_count-aware 스키마.
+    """
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
     # Sonnet 5 는 adaptive thinking 이 기본이라 max_tokens 에 사고 토큰 여유가 필요.
     # effort=low: 파이프라인 지연을 gpt-3.5 수준으로 유지.
@@ -131,7 +161,7 @@ def _generate_with_claude(prompt):
         max_tokens=4000,
         output_config={
             "effort": "low",
-            "format": {"type": "json_schema", "schema": SHORTS_OUTPUT_SCHEMA},
+            "format": {"type": "json_schema", "schema": schema},
         },
         system="당신은 유능한 영상 스크립트 작가입니다.",
         messages=[{"role": "user", "content": prompt}],
@@ -143,7 +173,11 @@ def _generate_with_claude(prompt):
 
 
 def _generate_with_openai(prompt):
-    """OpenAI fallback — ANTHROPIC_API_KEY 미설정 배포 환경에서 기존 동작 유지."""
+    """OpenAI fallback — ANTHROPIC_API_KEY 미설정 배포 환경에서 기존 동작 유지.
+
+    구조화 출력(JSON 스키마)을 쓰지 않으므로 scene_count 개수 강제가 안 됨 —
+    후처리 패딩/절단(_normalize_scripts)에 전적으로 의존 (architecture.md §3-3).
+    """
     import openai
 
     client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
@@ -159,20 +193,42 @@ def _generate_with_openai(prompt):
     return response.choices[0].message.content.strip()
 
 
-def summarize_for_shorts_sets(text, category: str = "restaurant"):
-    """카테고리에 따라 다른 프롬프트로 쇼츠용 title+scripts(5개) 생성.
+def _normalize_scripts(scripts: list, scene_count: int) -> list:
+    """scripts 배열 길이를 scene_count(N)에 정확히 맞춘다.
+
+    architecture.md §3-4 — 기존 "6개면 인덱스4 제거" 같은 특수 분기는 완전히 제거.
+    N=6 처럼 6이 정상값일 수 있는 케이스와 충돌하기 때문. 초과분은 뒤에서 자르고,
+    부족분은 빈 스크립트로 패딩한다.
+    """
+    if len(scripts) > scene_count:
+        scripts = scripts[:scene_count]
+    while len(scripts) < scene_count:
+        scripts.append({"script": ""})
+    return scripts
+
+
+def summarize_for_shorts_sets(
+    text,
+    category: str = "restaurant",
+    scene_count: int = 5,
+    hook_prompt: str = "",
+):
+    """카테고리 × 컨셉 샘플 두 축을 동시에 반영해 쇼츠용 title+scripts(N개) 생성.
 
     ANTHROPIC_API_KEY 가 있으면 Claude Sonnet, 없으면 기존 OpenAI 로 동작.
 
     Args:
         text: 블로그 본문
-        category: 'restaurant' (맛집, 기존) 또는 'general' (일반 블로그)
+        category: 'restaurant' (맛집, classifier.py 자동 분류) 또는 'general' (일반 블로그)
+        scene_count: N — 선택된 concept_sample 의 scene_count (기본 5, 하위호환용)
+        hook_prompt: 선택된 concept_sample 의 훅 작성 지침 (concept_samples.py)
     """
     template = RESTAURANT_PROMPT if category == "restaurant" else GENERAL_PROMPT
-    prompt = template.format(text=text)
+    prompt = template.format(text=text, scene_count=scene_count, hook_prompt=hook_prompt)
+    schema = build_shorts_output_schema(scene_count)
     try:
         if os.environ.get("ANTHROPIC_API_KEY"):
-            content = _generate_with_claude(prompt)
+            content = _generate_with_claude(prompt, schema)
         else:
             print("[summarize] ANTHROPIC_API_KEY 미설정 — OpenAI fallback 사용")
             content = _generate_with_openai(prompt)
@@ -187,19 +243,7 @@ def summarize_for_shorts_sets(text, category: str = "restaurant"):
     try:
         obj = json.loads(content)
         title = obj.get("title", "")
-        scripts = obj.get("scripts", [])
-
-        # scripts가 6개면 마지막(5번 인덱스)을 빼고 0~4번(총 5개)만 남김
-        if len(scripts) == 6:
-            print(f"[경고] 모델이 6개의 스크립트를 반환했습니다. 5번째(인덱스 4) 스크립트를 제외합니다.")
-            scripts = [scripts[0], scripts[1], scripts[2], scripts[3], scripts[5]]
-        # 5개 초과(7개 이상)면 앞 5개만 사용
-        elif len(scripts) > 5:
-            print(f"[경고] 모델이 {len(scripts)}개의 스크립트를 반환했습니다. 앞 5개만 사용합니다.")
-            scripts = scripts[:5]
-        # 5개 미만이면 빈 문자열로 채움
-        while len(scripts) < 5:
-            scripts.append({"script": ""})
+        scripts = _normalize_scripts(obj.get("scripts", []), scene_count)
     except Exception:
         try:
             json_str = extract_json_from_codeblock(content)
@@ -207,19 +251,7 @@ def summarize_for_shorts_sets(text, category: str = "restaurant"):
             fixed_content = fix_json_keys(fixed_content)
             obj = json.loads(fixed_content)
             title = obj.get("title", "")
-            scripts = obj.get("scripts", [])
-
-            # scripts가 6개면 마지막(5번 인덱스)을 빼고 0~4번(총 5개)만 남김
-            if len(scripts) == 6:
-                print(f"[경고] 모델이 6개의 스크립트를 반환했습니다. 5번째(인덱스 4) 스크립트를 제외합니다.")
-                scripts = [scripts[0], scripts[1], scripts[2], scripts[3], scripts[5]]
-            # 5개 초과(7개 이상)면 앞 5개만 사용
-            elif len(scripts) > 5:
-                print(f"[경고] 모델이 {len(scripts)}개의 스크립트를 반환했습니다. 앞 5개만 사용합니다.")
-                scripts = scripts[:5]
-            # 5개 미만이면 빈 문자열로 채움
-            while len(scripts) < 5:
-                scripts.append({"script": ""})
+            scripts = _normalize_scripts(obj.get("scripts", []), scene_count)
         except Exception as e:
             print(f"Claude 응답 파싱 실패: {e}")
             title = ""

--- a/auto_video_create_server/tests/test_cycle3_subtitle.py
+++ b/auto_video_create_server/tests/test_cycle3_subtitle.py
@@ -151,23 +151,31 @@ class TestValidateSubtitleSettings(unittest.TestCase):
 
 
 class TestApplySubtitleSettingsToVariables(unittest.TestCase):
+    """
+    sprint-4 (B-2) 갱신: 모듈 레벨 SUBTITLE_SUFFIXES 상수는 폐기되고
+    subtitle_element_suffixes 가 함수 인자로 전달된다(샘플별 룩업).
+    기존 5개 테스트 값(6K5/JTM/MDV/5Z2/D6M, 폐기된 기존 템플릿 전용)은
+    "임의의 suffix 목록" 예시로 그대로 재사용한다 — 검증 대상은 로직이지 이 값 자체가 아니다.
+    """
+
+    LEGACY_SUFFIXES = ["6K5", "JTM", "MDV", "5Z2", "D6M"]
 
     def test_none_settings_does_nothing(self):
         """subtitle_settings=None 이면 variables 변경 없음."""
         from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         variables = {}
-        apply_subtitle_settings_to_variables(variables, None)
+        apply_subtitle_settings_to_variables(variables, None, self.LEGACY_SUFFIXES)
         self.assertEqual(variables, {})
 
     def test_empty_settings_does_nothing(self):
         from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         variables = {}
-        apply_subtitle_settings_to_variables(variables, {})
+        apply_subtitle_settings_to_variables(variables, {}, self.LEGACY_SUFFIXES)
         self.assertEqual(variables, {})
 
     def test_full_settings_injects_all(self):
-        """완전한 설정값 → title + 5개 subtitle 모두 주입."""
-        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        """완전한 설정값 → title + suffix 개수만큼 subtitle 모두 주입."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         settings = {
             "title": {
                 "font_family": "Black Han Sans",
@@ -181,15 +189,15 @@ class TestApplySubtitleSettingsToVariables(unittest.TestCase):
             },
         }
         variables = {}
-        apply_subtitle_settings_to_variables(variables, settings)
+        apply_subtitle_settings_to_variables(variables, settings, self.LEGACY_SUFFIXES)
 
         # 제목 검증
         self.assertEqual(variables["title.font_family"], "Black Han Sans")
         self.assertEqual(variables["title.fill_color"], "#fff100")
         self.assertEqual(variables["title.font_size"], "12 vmin")  # L
 
-        # 자막 5개 검증
-        for suffix in SUBTITLE_SUFFIXES:
+        # 자막(suffix 개수만큼) 검증
+        for suffix in self.LEGACY_SUFFIXES:
             self.assertEqual(variables[f"Subtitles-{suffix}.font_family"], "Noto Sans KR")
             self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "4 vmin")   # S
             self.assertEqual(variables[f"Subtitles-{suffix}.fill_color"], "#ffffff")
@@ -213,43 +221,43 @@ class TestApplySubtitleSettingsToVariables(unittest.TestCase):
             },
         }
         variables = {}
-        apply_subtitle_settings_to_variables(variables, settings)
+        apply_subtitle_settings_to_variables(variables, settings, self.LEGACY_SUFFIXES)
         self.assertNotIn("title.font_size", variables)
 
     def test_subtitle_size_M_is_6vmin(self):
         """자막 font_size=M → 6 vmin (기존 템플릿 기본값과 동일)."""
-        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         settings = {
             "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
             "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
         }
         variables = {}
-        apply_subtitle_settings_to_variables(variables, settings)
-        for suffix in SUBTITLE_SUFFIXES:
+        apply_subtitle_settings_to_variables(variables, settings, self.LEGACY_SUFFIXES)
+        for suffix in self.LEGACY_SUFFIXES:
             self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "6 vmin")
 
     def test_subtitle_size_L_is_8vmin(self):
-        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         settings = {
             "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
             "subtitle": {"font_family": "Noto Sans KR", "font_size": "L", "fill_color": "#ffffff"},
         }
         variables = {}
-        apply_subtitle_settings_to_variables(variables, settings)
-        for suffix in SUBTITLE_SUFFIXES:
+        apply_subtitle_settings_to_variables(variables, settings, self.LEGACY_SUFFIXES)
+        for suffix in self.LEGACY_SUFFIXES:
             self.assertEqual(variables[f"Subtitles-{suffix}.font_size"], "8 vmin")
 
-    def test_5_subtitle_elements_all_set(self):
-        """자막 element 정확히 5개(6K5/JTM/MDV/5Z2/D6M) 모두 키 생성."""
-        from services.subtitle_settings_service import apply_subtitle_settings_to_variables, SUBTITLE_SUFFIXES
+    def test_all_suffix_elements_set(self):
+        """전달된 suffix 목록 전부 키 생성 (개수 무관, N-가변 지원 확인)."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         settings = {
             "title": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#fff100"},
             "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
         }
         variables = {}
-        apply_subtitle_settings_to_variables(variables, settings)
-        self.assertEqual(len(SUBTITLE_SUFFIXES), 5)
-        for suffix in SUBTITLE_SUFFIXES:
+        apply_subtitle_settings_to_variables(variables, settings, self.LEGACY_SUFFIXES)
+        self.assertEqual(len(self.LEGACY_SUFFIXES), 5)
+        for suffix in self.LEGACY_SUFFIXES:
             self.assertIn(f"Subtitles-{suffix}.font_family", variables)
             self.assertIn(f"Subtitles-{suffix}.font_size", variables)
             self.assertIn(f"Subtitles-{suffix}.fill_color", variables)
@@ -259,15 +267,44 @@ class TestApplySubtitleSettingsToVariables(unittest.TestCase):
         """settings=None 이면 기존 variables 그대로 유지."""
         from services.subtitle_settings_service import apply_subtitle_settings_to_variables
         variables = {"image1.source": "https://example.com/img.jpg"}
-        apply_subtitle_settings_to_variables(variables, None)
+        apply_subtitle_settings_to_variables(variables, None, self.LEGACY_SUFFIXES)
         self.assertIn("image1.source", variables)
 
+    def test_none_suffixes_skips_subtitle_injection_but_keeps_title(self):
+        """sprint-4: subtitle_element_suffixes=None(DEP-S4-06 미해소) 이면 자막 주입은
+        건너뛰지만 title 은 suffix 와 무관하므로 그대로 적용된다."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        settings = {
+            "title": {"font_family": "Black Han Sans", "font_size": "L", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings, None)
+        self.assertEqual(variables["title.font_family"], "Black Han Sans")
+        self.assertEqual(variables["title.font_size"], "12 vmin")
+        self.assertEqual(len([k for k in variables if k.startswith("Subtitles-")]), 0)
 
-class TestSubtitleSuffixes(unittest.TestCase):
-    def test_suffix_list_exact(self):
-        """SUBTITLE_SUFFIXES 가 정확히 architecture.md DEP-01 확인값과 일치."""
-        from services.subtitle_settings_service import SUBTITLE_SUFFIXES
-        self.assertEqual(SUBTITLE_SUFFIXES, ["6K5", "JTM", "MDV", "5Z2", "D6M"])
+    def test_empty_suffixes_list_skips_subtitle_injection(self):
+        """subtitle_element_suffixes=[] 도 None 과 동일하게 자막 주입을 건너뛴다."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        settings = {
+            "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings, [])
+        self.assertEqual(len([k for k in variables if k.startswith("Subtitles-")]), 0)
+
+    def test_default_suffixes_param_is_none(self):
+        """subtitle_element_suffixes 인자를 생략하면 기본값 None → 자막 주입 스킵."""
+        from services.subtitle_settings_service import apply_subtitle_settings_to_variables
+        settings = {
+            "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        }
+        variables = {}
+        apply_subtitle_settings_to_variables(variables, settings)
+        self.assertEqual(len([k for k in variables if k.startswith("Subtitles-")]), 0)
 
 
 class TestSizeMapConstants(unittest.TestCase):

--- a/auto_video_create_server/tests/test_sprint4_concept_samples.py
+++ b/auto_video_create_server/tests/test_sprint4_concept_samples.py
@@ -1,0 +1,295 @@
+"""
+test_sprint4_concept_samples.py — sprint-4 (B-2) 단위 테스트
+
+컨셉 영상 샘플 4종 + 가변 스크립트/장면 수(N) 관련 순수 로직 검증.
+외부 의존성(S3, Creatomate, Claude/OpenAI API) 없이 mock 으로 대체.
+pytest 없이 stdlib unittest 사용 (기존 test_cycle3_subtitle.py 관행 재사용).
+"""
+
+import copy
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# 서버 루트를 sys.path 에 추가
+_SERVER_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SERVER_ROOT not in sys.path:
+    sys.path.insert(0, _SERVER_ROOT)
+
+# create_creatomate_video.py 는 모듈 임포트 시점에 CREATOMATE_API_KEY 를 읽는다 —
+# 테스트 환경에 없으면 값 없이도 임포트는 되도록 placeholder 를 미리 세팅.
+os.environ.setdefault("CREATOMATE_API_KEY", "test-dummy-key")
+
+
+# ─────────────────────────────────────────────
+# concept_samples 테스트
+# ─────────────────────────────────────────────
+
+class TestConceptSamples(unittest.TestCase):
+
+    def test_four_samples_defined(self):
+        from services.concept_samples import SAMPLE_DEFINITIONS
+        self.assertEqual(
+            set(SAMPLE_DEFINITIONS.keys()),
+            {"sample_1", "sample_2", "sample_3", "sample_4"},
+        )
+
+    def test_exactly_one_default_sample(self):
+        from services.concept_samples import SAMPLE_DEFINITIONS
+        defaults = [s for s in SAMPLE_DEFINITIONS.values() if s["is_default"]]
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(defaults[0]["concept_sample_id"], "sample_1")
+
+    def test_scene_count_placeholder_values(self):
+        """api-contract.md / data-model.md placeholder 값(s1=4/s2=6/s3=5/s4=4)과 정합."""
+        from services.concept_samples import SAMPLE_DEFINITIONS
+        expected = {"sample_1": 4, "sample_2": 6, "sample_3": 5, "sample_4": 4}
+        for sid, scene_count in expected.items():
+            self.assertEqual(SAMPLE_DEFINITIONS[sid]["scene_count"], scene_count)
+
+    def test_get_sample_known_id(self):
+        from services.concept_samples import get_sample
+        sample = get_sample("sample_2")
+        self.assertEqual(sample["concept_sample_id"], "sample_2")
+        self.assertEqual(sample["scene_count"], 6)
+
+    def test_get_sample_unknown_id_falls_back_to_default(self):
+        """미인식 값이면 sample_1 로 폴백 (api-contract.md '미선택 통과 허용')."""
+        from services.concept_samples import get_sample, DEFAULT_SAMPLE_ID
+        sample = get_sample("does_not_exist")
+        self.assertEqual(sample["concept_sample_id"], DEFAULT_SAMPLE_ID)
+
+    def test_get_sample_none_falls_back_to_default(self):
+        from services.concept_samples import get_sample, DEFAULT_SAMPLE_ID
+        sample = get_sample(None)
+        self.assertEqual(sample["concept_sample_id"], DEFAULT_SAMPLE_ID)
+
+    def test_get_scene_count_helper(self):
+        from services.concept_samples import get_scene_count
+        self.assertEqual(get_scene_count("sample_3"), 5)
+        self.assertEqual(get_scene_count(None), 4)  # sample_1 폴백
+
+    def test_get_template_id_placeholder_is_none(self):
+        """전 샘플 template_id 가 placeholder(None) 상태 — DEP-S4-01 미해소."""
+        from services.concept_samples import get_template_id
+        for sid in ("sample_1", "sample_2", "sample_3", "sample_4"):
+            self.assertIsNone(get_template_id(sid, "test"))
+            self.assertIsNone(get_template_id(sid, "production"))
+
+    def test_get_template_id_env_key_normalization(self):
+        """env 값이 'production'(대소문자 무관) 이 아니면 전부 'test' 키로 취급."""
+        from services.concept_samples import get_template_id
+        # 값 자체는 placeholder(None)이라 결과는 같지만, KeyError 없이 안전하게 처리되는지 확인
+        self.assertIsNone(get_template_id("sample_1", None))
+        self.assertIsNone(get_template_id("sample_1", ""))
+        self.assertIsNone(get_template_id("sample_1", "PRODUCTION"))
+        self.assertIsNone(get_template_id("sample_1", "staging"))
+
+    def test_list_samples_public_excludes_internal_fields(self):
+        """BE 내부 전용 필드(creatomate_template_id/subtitle_element_suffixes/hook_prompt) 비노출."""
+        from services.concept_samples import list_samples_public
+        samples = list_samples_public()
+        self.assertEqual(len(samples), 4)
+        expected_keys = {
+            "concept_sample_id", "name", "is_default",
+            "scene_count", "hero_still_url", "sample_video_url",
+        }
+        for s in samples:
+            self.assertEqual(set(s.keys()), expected_keys)
+            self.assertNotIn("creatomate_template_id", s)
+            self.assertNotIn("subtitle_element_suffixes", s)
+            self.assertNotIn("hook_prompt", s)
+
+    def test_list_samples_public_order_and_names(self):
+        from services.concept_samples import list_samples_public
+        samples = list_samples_public()
+        names = {s["concept_sample_id"]: s["name"] for s in samples}
+        self.assertEqual(names["sample_1"], "컨셉 1")
+        self.assertEqual(names["sample_2"], "컨셉 2")
+        self.assertEqual(names["sample_3"], "컨셉 3")
+        self.assertEqual(names["sample_4"], "컨셉 4")
+
+
+# ─────────────────────────────────────────────
+# summarize.py — scene_count 가변화 테스트
+# ─────────────────────────────────────────────
+
+class TestBuildShortsOutputSchema(unittest.TestCase):
+
+    def test_min_max_items_match_scene_count(self):
+        from services.summarize import build_shorts_output_schema
+        schema = build_shorts_output_schema(6)
+        self.assertEqual(schema["properties"]["scripts"]["minItems"], 6)
+        self.assertEqual(schema["properties"]["scripts"]["maxItems"], 6)
+
+    def test_does_not_mutate_module_constant(self):
+        """deepcopy 미적용 회귀 방지 — 원본 SHORTS_OUTPUT_SCHEMA 에 minItems 가 새지 않아야 함."""
+        from services.summarize import build_shorts_output_schema, SHORTS_OUTPUT_SCHEMA
+        build_shorts_output_schema(4)
+        build_shorts_output_schema(6)
+        self.assertNotIn("minItems", SHORTS_OUTPUT_SCHEMA["properties"]["scripts"])
+        self.assertNotIn("maxItems", SHORTS_OUTPUT_SCHEMA["properties"]["scripts"])
+
+
+class TestNormalizeScripts(unittest.TestCase):
+    """architecture.md §3-4 — "6개면 인덱스4 제거" 특수분기 제거 + 일반 패딩/절단."""
+
+    def test_exact_length_untouched(self):
+        from services.summarize import _normalize_scripts
+        scripts = [{"script": f"s{i}"} for i in range(5)]
+        result = _normalize_scripts(list(scripts), 5)
+        self.assertEqual(result, scripts)
+
+    def test_pads_when_short(self):
+        from services.summarize import _normalize_scripts
+        scripts = [{"script": "a"}, {"script": "b"}]
+        result = _normalize_scripts(scripts, 5)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0], {"script": "a"})
+        self.assertEqual(result[-1], {"script": ""})
+
+    def test_truncates_when_long(self):
+        from services.summarize import _normalize_scripts
+        scripts = [{"script": f"s{i}"} for i in range(8)]
+        result = _normalize_scripts(scripts, 5)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result, [{"script": f"s{i}"} for i in range(5)])
+
+    def test_six_is_not_special_cased_when_scene_count_is_six(self):
+        """N=6 일 때 6개 응답은 정상값 — 과거처럼 인덱스4 를 제거하면 안 됨."""
+        from services.summarize import _normalize_scripts
+        scripts = [{"script": f"s{i}"} for i in range(6)]
+        result = _normalize_scripts(list(scripts), 6)
+        self.assertEqual(result, scripts)
+        self.assertEqual(len(result), 6)
+
+    def test_six_truncated_to_five_when_scene_count_is_five(self):
+        from services.summarize import _normalize_scripts
+        scripts = [{"script": f"s{i}"} for i in range(6)]
+        result = _normalize_scripts(scripts, 5)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result, [{"script": f"s{i}"} for i in range(5)])
+
+
+class TestSummarizeForShortsSetsPromptFormatting(unittest.TestCase):
+    """프롬프트 템플릿에 scene_count/hook_prompt 가 정상적으로 주입되는지 (format 에러 없이)."""
+
+    def test_restaurant_prompt_formats_without_error(self):
+        from services.summarize import RESTAURANT_PROMPT
+        prompt = RESTAURANT_PROMPT.format(text="본문", scene_count=6, hook_prompt="훅 지침")
+        self.assertIn("6개", prompt)
+        self.assertIn("훅 지침", prompt)
+
+    def test_general_prompt_formats_without_error(self):
+        from services.summarize import GENERAL_PROMPT
+        prompt = GENERAL_PROMPT.format(text="본문", scene_count=4, hook_prompt="훅 지침2")
+        self.assertIn("4개", prompt)
+        self.assertIn("훅 지침2", prompt)
+
+    def test_summarize_uses_scene_count_and_hook_prompt_with_claude_path(self):
+        """ANTHROPIC_API_KEY 존재 시 Claude 경로 호출 + scene_count/hook_prompt 가 프롬프트에 반영."""
+        from services import summarize
+
+        captured = {}
+
+        def fake_generate_with_claude(prompt, schema):
+            captured["prompt"] = prompt
+            captured["schema"] = schema
+            return '{"title": "t", "scripts": [{"script": "a"}, {"script": "b"}]}'
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "dummy"}):
+            with patch.object(summarize, "_generate_with_claude", side_effect=fake_generate_with_claude):
+                title, scripts = summarize.summarize_for_shorts_sets(
+                    "블로그 본문", category="restaurant", scene_count=4, hook_prompt="특별 훅 지침"
+                )
+
+        self.assertEqual(title, "t")
+        self.assertEqual(len(scripts), 4)  # 2개 응답 → 4개로 패딩
+        self.assertIn("특별 훅 지침", captured["prompt"])
+        self.assertEqual(captured["schema"]["properties"]["scripts"]["minItems"], 4)
+        self.assertEqual(captured["schema"]["properties"]["scripts"]["maxItems"], 4)
+
+
+# ─────────────────────────────────────────────
+# create_creatomate_video.py — concept_sample_id 게이팅 테스트
+# ─────────────────────────────────────────────
+
+class TestCreateCreatomateVideoTemplateGating(unittest.TestCase):
+    """architecture.md §4-2 — template_id 미확보(placeholder) 시 방어적 에러 반환."""
+
+    def test_unconfigured_sample_returns_error_without_calling_api(self):
+        from services import create_creatomate_video as ccv
+
+        with patch.object(ccv, "requests") as mock_requests:
+            result = ccv.create_creatomate_video(
+                audio_paths=["a.mp3", "b.mp3"],
+                scripts=[{"script": "a"}, {"script": "b"}],
+                concept_sample_id="sample_1",  # placeholder → template_id=None
+                title="제목",
+                user_id=None,
+            )
+            self.assertEqual(result.get("error"), "concept_sample_template_not_configured")
+            mock_requests.post.assert_not_called()
+
+    def test_unknown_concept_sample_id_falls_back_to_default_and_still_unconfigured(self):
+        from services import create_creatomate_video as ccv
+
+        with patch.object(ccv, "requests") as mock_requests:
+            result = ccv.create_creatomate_video(
+                audio_paths=["a.mp3"],
+                scripts=[{"script": "a"}],
+                concept_sample_id="unknown_id",
+                user_id=None,
+            )
+            self.assertEqual(result.get("error"), "concept_sample_template_not_configured")
+            mock_requests.post.assert_not_called()
+
+    def test_configured_template_builds_n_audio_variables(self):
+        """template_id 가 있다고 가정하면 audio1~audioN modifications 가 N개 생성된다."""
+        from services import create_creatomate_video as ccv
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {"id": "render-123"}
+
+        with patch.object(ccv, "get_template_id", return_value="dummy-template-id"):
+            with patch.object(ccv, "requests") as mock_requests:
+                mock_requests.post.return_value = fake_response
+                result = ccv.create_creatomate_video(
+                    audio_paths=["a1.mp3", "a2.mp3", "a3.mp3"],
+                    scripts=[{"script": "a"}, {"script": "b"}, {"script": "c"}],
+                    concept_sample_id="sample_3",
+                    user_id=None,
+                )
+        self.assertEqual(result, {"id": "render-123"})
+        sent_payload = mock_requests.post.call_args.kwargs["data"]
+        import json as _json
+        payload = _json.loads(sent_payload)
+        self.assertEqual(payload["template_id"], "dummy-template-id")
+        for i in range(1, 4):
+            self.assertIn(f"audio{i}.source", payload["modifications"])
+        self.assertNotIn("audio4.source", payload["modifications"])
+
+
+class TestGetCreatomateVarsGeneralized(unittest.TestCase):
+    """data-model.md §4 — N-일반화된 시그니처(현재 라이브 경로 미사용, 대기 상태)."""
+
+    def test_scene_count_four(self):
+        from services.create_creatomate_video import get_creatomate_vars
+        result = get_creatomate_vars([1.0, 2.0, 3.0, 4.0], 4)
+        self.assertEqual(result["composition_4.time"], 6.0)  # 1+2+3
+        self.assertEqual(result["composition_4.duration"], 4.0)
+        self.assertEqual(result["duration"], 10.0)
+        self.assertNotIn("composition_5.time", result)
+
+    def test_scene_count_six(self):
+        from services.create_creatomate_video import get_creatomate_vars
+        durations = [1.0] * 6
+        result = get_creatomate_vars(durations, 6)
+        self.assertEqual(result["composition_6.time"], 5.0)
+        self.assertEqual(result["duration"], 6.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Sprint-4 — 컨셉 영상 샘플

무드 프리셋 → **컨셉 영상 샘플 4종(전부 신규)** 로 재정의. 샘플별로 생성 스크립트/장면 수가 가변.

### 확정 설계 (Phase A-B0)
- **input**: 컨셉 샘플 카드 4장(대표 스틸 + N장면 배지 + "영상 보기" 모달) — 샘플1 기본 선택, 미선택 통과
- **select**: sprint-3 2열 유지, 스크립트/이미지 슬롯이 샘플별 개수(N) 가변. 샘플 변경은 "다시하기"
- **저장**: 샘플 정의 = 코드 상수 `services/concept_samples.py`
- **API**: `GET /api/blog/concept-samples` 신설 + extract-all/generate-video에 `concept_sample_id`
- **가변화**: 하드코딩 "5" 8곳 → `scene_count`/`scripts.length`

### ⚠️ 릴리즈 게이트
- 샘플 4종 실제 룩/개수/영상/**Creatomate 템플릿은 PO 추후 제공(placeholder)**
- **prod 릴리즈는 최소 sample_1 템플릿 확보 전까지 금지** — 미확보 시 영상 생성 100% 실패 (기존 기능 대체 사이클)

### 진행
- [x] Phase A 디자인 / B-0 아키텍처 확정
- [ ] B-2 백엔드 (concept_samples, API, 가변 N)
- [ ] B-3 프론트 (카드/모달, 가변 슬롯)
- [ ] C QA
- [ ] Creatomate 템플릿 확보 후 실동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)