### PR TITLE
feat: 자막 스타일 이름 붙인 템플릿(최대 5개) — VOC 반영

### DIFF
--- a/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
+++ b/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
@@ -9,6 +9,9 @@ import {
   ToggleButton,
   Snackbar,
   Alert,
+  Button,
+  TextField,
+  CircularProgress,
 } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
@@ -27,6 +30,14 @@ export interface SubtitleSettings {
   subtitle: StyleSetting;
 }
 
+// VOC: 폰트/색상을 이름 붙여 최대 5개까지 저장·재사용하는 스타일 템플릿
+export interface SubtitleTemplate {
+  id: string;
+  name: string;
+  title: StyleSetting;
+  subtitle: StyleSetting;
+}
+
 interface FontItem {
   family: string;
   category: string;
@@ -34,6 +45,8 @@ interface FontItem {
 }
 
 // ── Constants ──────────────────────────────────────────────────────────────
+
+const MAX_TEMPLATES = 5;
 
 const DEFAULT_SETTINGS: SubtitleSettings = {
   title: { font_family: "Black Han Sans", font_size: "M", fill_color: "#fff100" },
@@ -48,6 +61,7 @@ const SIZE_PX: Record<"S" | "M" | "L", { title: number; subtitle: number }> = {
 };
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+const TEMPLATES_URL = `${API_BASE_URL}/api/blog/subtitle-templates`;
 
 function authFetch(url: string, options: RequestInit = {}) {
   const userId = typeof window !== "undefined" ? localStorage.getItem("user_id") : null;
@@ -55,6 +69,58 @@ function authFetch(url: string, options: RequestInit = {}) {
     ...options,
     headers: { ...(options.headers || {}), "X-USER-ID": userId ?? "" },
   });
+}
+
+// ── Helpers: normalize server payloads defensively ─────────────────────────
+
+function normalizeStyleSetting(raw: unknown, fallback: StyleSetting): StyleSetting {
+  const r = (raw ?? {}) as Partial<StyleSetting>;
+  return {
+    font_family: r.font_family ?? fallback.font_family,
+    font_size: (r.font_size as "S" | "M" | "L") ?? fallback.font_size,
+    fill_color: r.fill_color ?? fallback.fill_color,
+  };
+}
+
+function normalizeTemplate(raw: unknown): SubtitleTemplate | null {
+  const r = raw as { id?: string | number; name?: string; title?: unknown; subtitle?: unknown } | null;
+  if (!r || r.id === undefined || r.id === null) return null;
+  return {
+    id: String(r.id),
+    name: r.name ?? "",
+    title: normalizeStyleSetting(r.title, DEFAULT_SETTINGS.title),
+    subtitle: normalizeStyleSetting(r.subtitle, DEFAULT_SETTINGS.subtitle),
+  };
+}
+
+// POST/PUT 응답이 { template: {...} } 또는 {...} 그대로 올 수 있어 방어적으로 파싱
+function extractTemplate(data: unknown): SubtitleTemplate | null {
+  const wrapped = (data as { template?: unknown } | null)?.template ?? data;
+  return normalizeTemplate(wrapped);
+}
+
+// BE 에러 응답 형식이 두 가지로 섞여 있음: 5개 초과는 { error_code, message } 최상위,
+// 그 외 400/404 는 FastAPI 기본 { detail: "문자열" }. 가능한 한 서버 메시지를 그대로 보여준다.
+function extractErrorMessage(data: unknown, fallback: string): string {
+  const d = data as { error_code?: string; message?: string; detail?: string } | null;
+  if (d?.error_code === "template_limit_reached") {
+    return "템플릿은 최대 5개까지 저장할 수 있어요";
+  }
+  if (typeof d?.detail === "string" && d.detail.trim()) return d.detail;
+  if (typeof d?.message === "string" && d.message.trim()) return d.message;
+  return fallback;
+}
+
+function isSameStyle(a: StyleSetting, b: StyleSetting) {
+  return (
+    a.font_family === b.font_family &&
+    a.font_size === b.font_size &&
+    a.fill_color === b.fill_color
+  );
+}
+
+function isSameSettings(a: SubtitleSettings, b: SubtitleSettings) {
+  return isSameStyle(a.title, b.title) && isSameStyle(a.subtitle, b.subtitle);
 }
 
 // ── MiniChip ──────────────────────────────────────────────────────────────
@@ -414,64 +480,126 @@ function Preview9x16({ settings }: { settings: SubtitleSettings }) {
   );
 }
 
+// ── TemplateChip ──────────────────────────────────────────────────────────
+
+function TemplateChip({
+  template,
+  selected,
+  onClick,
+}: {
+  template: SubtitleTemplate;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        px: 1.5,
+        py: 0.6,
+        borderRadius: 999,
+        border: selected ? "1.5px solid #1976d2" : "1.5px solid #e3e6ef",
+        bgcolor: selected ? "#1976d2" : "#fff",
+        color: selected ? "#fff" : "#444",
+        fontSize: 13,
+        fontWeight: selected ? 700 : 500,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        userSelect: "none",
+        transition: "all 0.15s",
+        "&:hover": { borderColor: "#1976d2" },
+      }}
+    >
+      {template.name || "이름 없는 템플릿"}
+    </Box>
+  );
+}
+
 // ── SubtitleStyleEditor (Main) ────────────────────────────────────────────
 
 interface SubtitleStyleEditorProps {
   onSettingsChange: (settings: SubtitleSettings) => void;
 }
 
+type NameDialogMode = "create" | "rename" | null;
+type ActionKind = "save" | "create" | "rename" | "delete" | null;
+
 export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleEditorProps) {
   const [expanded, setExpanded] = useState(false);
+
+  // 템플릿 목록 + 현재 선택된 템플릿
+  const [templates, setTemplates] = useState<SubtitleTemplate[]>([]);
+  const [templatesLoading, setTemplatesLoading] = useState(false);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
+
+  // 편집 컨트롤(제목/자막)에 반영되는 현재 편집 값 — 선택된 템플릿 값으로 초기화되고,
+  // 사용자가 폰트/크기/색을 바꾸면 여기만 바뀐다 (명시적으로 저장하기 전까지 서버 반영 안 됨)
   const [settings, setSettings] = useState<SubtitleSettings>(DEFAULT_SETTINGS);
+
   const [fonts, setFonts] = useState<FontItem[]>([]);
   const [fontsLoading, setFontsLoading] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerTarget, setPickerTarget] = useState<"title" | "subtitle">("title");
-  const [toastOpen, setToastOpen] = useState(false);
-  const [hasChanged, setHasChanged] = useState(false);
 
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isDefaultSettings = useCallback((s: SubtitleSettings) => {
-    return (
-      s.title.font_family === DEFAULT_SETTINGS.title.font_family &&
-      s.title.font_size === DEFAULT_SETTINGS.title.font_size &&
-      s.title.fill_color === DEFAULT_SETTINGS.title.fill_color &&
-      s.subtitle.font_family === DEFAULT_SETTINGS.subtitle.font_family &&
-      s.subtitle.font_size === DEFAULT_SETTINGS.subtitle.font_size &&
-      s.subtitle.fill_color === DEFAULT_SETTINGS.subtitle.fill_color
-    );
+  const [nameDialogMode, setNameDialogMode] = useState<NameDialogMode>(null);
+  const [nameInput, setNameInput] = useState("");
+  const [deleteConfirming, setDeleteConfirming] = useState(false);
+  const [actionLoading, setActionLoading] = useState<ActionKind>(null);
+
+  const [toast, setToast] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({
+    open: false,
+    message: "",
+    severity: "success",
+  });
+
+  const showToast = useCallback((message: string, severity: "success" | "error" = "success") => {
+    setToast({ open: true, message, severity });
   }, []);
 
-  // Load settings on mount
+  const selectedTemplate = templates.find((t) => t.id === selectedTemplateId) ?? null;
+  const baselineSettings: SubtitleSettings = selectedTemplate
+    ? { title: selectedTemplate.title, subtitle: selectedTemplate.subtitle }
+    : DEFAULT_SETTINGS;
+  const hasChanged = !isSameSettings(settings, baselineSettings);
+
+  // Load templates on mount (헤더의 미니 칩 + generate-video 초기값이 펼치기 전에도 맞도록)
   useEffect(() => {
+    let cancelled = false;
     const load = async () => {
+      setTemplatesLoading(true);
       try {
-        const res = await authFetch(`${API_BASE_URL}/api/blog/subtitle-settings`);
-        if (!res.ok) return;
+        const res = await authFetch(TEMPLATES_URL);
+        if (!res.ok) {
+          if (!cancelled) onSettingsChange(DEFAULT_SETTINGS);
+          return;
+        }
         const data = await res.json();
-        if (data.settings) {
-          const loaded: SubtitleSettings = {
-            title: {
-              font_family: data.settings.title?.font_family ?? DEFAULT_SETTINGS.title.font_family,
-              font_size: (data.settings.title?.font_size as "S" | "M" | "L") ?? "M",
-              fill_color: data.settings.title?.fill_color ?? DEFAULT_SETTINGS.title.fill_color,
-            },
-            subtitle: {
-              font_family: data.settings.subtitle?.font_family ?? DEFAULT_SETTINGS.subtitle.font_family,
-              font_size: (data.settings.subtitle?.font_size as "S" | "M" | "L") ?? "M",
-              fill_color: data.settings.subtitle?.fill_color ?? DEFAULT_SETTINGS.subtitle.fill_color,
-            },
-          };
+        if (cancelled) return;
+        const rawList = Array.isArray(data?.templates) ? data.templates : [];
+        const list = rawList
+          .map((t: unknown) => normalizeTemplate(t))
+          .filter((t: SubtitleTemplate | null): t is SubtitleTemplate => t !== null);
+        setTemplates(list);
+        if (list.length > 0) {
+          setSelectedTemplateId(list[0].id);
+          const loaded: SubtitleSettings = { title: list[0].title, subtitle: list[0].subtitle };
           setSettings(loaded);
           onSettingsChange(loaded);
-          setHasChanged(!isDefaultSettings(loaded));
+        } else {
+          onSettingsChange(DEFAULT_SETTINGS);
         }
       } catch {
-        // silently fall back to defaults
+        // 네트워크 오류 등 — 기본값으로 폴백, generate-video는 그대로 동작
+        if (!cancelled) onSettingsChange(DEFAULT_SETTINGS);
+      } finally {
+        if (!cancelled) setTemplatesLoading(false);
       }
     };
     load();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Load fonts when picker is first opened
@@ -492,22 +620,6 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
     }
   }, [fonts.length]);
 
-  const debouncedSave = useCallback((newSettings: SubtitleSettings) => {
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(async () => {
-      try {
-        const res = await authFetch(`${API_BASE_URL}/api/blog/subtitle-settings`, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(newSettings),
-        });
-        if (res.ok) setToastOpen(true);
-      } catch {
-        // ignore save errors silently
-      }
-    }, 500);
-  }, []);
-
   const updateSection = useCallback(
     (section: "title" | "subtitle", patch: Partial<StyleSetting>) => {
       setSettings((prev) => {
@@ -516,19 +628,15 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
           [section]: { ...prev[section], ...patch },
         };
         onSettingsChange(next);
-        setHasChanged(!isDefaultSettings(next));
-        debouncedSave(next);
         return next;
       });
     },
-    [onSettingsChange, isDefaultSettings, debouncedSave]
+    [onSettingsChange]
   );
 
-  const handleReset = () => {
-    setSettings(DEFAULT_SETTINGS);
-    onSettingsChange(DEFAULT_SETTINGS);
-    setHasChanged(false);
-    debouncedSave(DEFAULT_SETTINGS);
+  const handleRevert = () => {
+    setSettings(baselineSettings);
+    onSettingsChange(baselineSettings);
   };
 
   const handleOpenPicker = (target: "title" | "subtitle") => {
@@ -540,6 +648,158 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
   const handleFontSelect = (fontFamily: string) => {
     updateSection(pickerTarget, { font_family: fontFamily });
     setPickerOpen(false);
+  };
+
+  // ── 템플릿 선택 ──────────────────────────────────────────────────────────
+
+  const handleSelectTemplate = (template: SubtitleTemplate) => {
+    setSelectedTemplateId(template.id);
+    const loaded: SubtitleSettings = { title: template.title, subtitle: template.subtitle };
+    setSettings(loaded);
+    onSettingsChange(loaded);
+    setNameDialogMode(null);
+    setDeleteConfirming(false);
+  };
+
+  // ── 액션: 현재 편집값 저장 (선택된 템플릿에 PUT) ────────────────────────
+
+  const handleSaveCurrent = async () => {
+    if (!selectedTemplateId) return;
+    setActionLoading("save");
+    try {
+      const res = await authFetch(`${TEMPLATES_URL}/${selectedTemplateId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: settings.title, subtitle: settings.subtitle }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => null);
+        const updated = extractTemplate(data);
+        setTemplates((prev) =>
+          prev.map((t) =>
+            t.id === selectedTemplateId
+              ? updated ?? { ...t, title: settings.title, subtitle: settings.subtitle }
+              : t
+          )
+        );
+        showToast("저장했어요");
+      } else {
+        const data = await res.json().catch(() => null);
+        showToast(extractErrorMessage(data, "저장하지 못했어요. 다시 시도해 주세요."), "error");
+      }
+    } catch {
+      showToast("저장하지 못했어요. 다시 시도해 주세요.", "error");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // ── 액션: 새 템플릿으로 저장 (POST) ──────────────────────────────────────
+
+  const openCreate = () => {
+    if (templates.length >= MAX_TEMPLATES) return;
+    setDeleteConfirming(false);
+    setNameDialogMode("create");
+    setNameInput(`템플릿 ${templates.length + 1}`);
+  };
+
+  const handleCreateConfirm = async () => {
+    const name = nameInput.trim();
+    if (!name) return;
+    setActionLoading("create");
+    try {
+      const res = await authFetch(TEMPLATES_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, title: settings.title, subtitle: settings.subtitle }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok) {
+        const created =
+          extractTemplate(data) ??
+          ({ id: `local-${Date.now()}`, name, title: settings.title, subtitle: settings.subtitle } as SubtitleTemplate);
+        setTemplates((prev) => [...prev, created]);
+        setSelectedTemplateId(created.id);
+        setNameDialogMode(null);
+        showToast("새 템플릿으로 저장했어요");
+      } else {
+        showToast(extractErrorMessage(data, "저장하지 못했어요. 다시 시도해 주세요."), "error");
+      }
+    } catch {
+      showToast("저장하지 못했어요. 다시 시도해 주세요.", "error");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // ── 액션: 이름 변경 (PUT name) ───────────────────────────────────────────
+
+  const openRename = () => {
+    if (!selectedTemplate) return;
+    setDeleteConfirming(false);
+    setNameDialogMode("rename");
+    setNameInput(selectedTemplate.name);
+  };
+
+  const handleRenameConfirm = async () => {
+    if (!selectedTemplateId) return;
+    const name = nameInput.trim();
+    if (!name) return;
+    setActionLoading("rename");
+    try {
+      const res = await authFetch(`${TEMPLATES_URL}/${selectedTemplateId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (res.ok) {
+        setTemplates((prev) => prev.map((t) => (t.id === selectedTemplateId ? { ...t, name } : t)));
+        setNameDialogMode(null);
+        showToast("이름을 변경했어요");
+      } else {
+        const data = await res.json().catch(() => null);
+        showToast(extractErrorMessage(data, "이름을 변경하지 못했어요. 다시 시도해 주세요."), "error");
+      }
+    } catch {
+      showToast("이름을 변경하지 못했어요. 다시 시도해 주세요.", "error");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  // ── 액션: 삭제 (DELETE, 최소 1개 유지) ───────────────────────────────────
+
+  const handleDelete = async () => {
+    if (!selectedTemplateId || templates.length <= 1) return;
+    setActionLoading("delete");
+    try {
+      const res = await authFetch(`${TEMPLATES_URL}/${selectedTemplateId}`, { method: "DELETE" });
+      if (res.ok) {
+        const remaining = templates.filter((t) => t.id !== selectedTemplateId);
+        setTemplates(remaining);
+        setDeleteConfirming(false);
+        const next = remaining[0] ?? null;
+        setSelectedTemplateId(next ? next.id : null);
+        const loaded: SubtitleSettings = next
+          ? { title: next.title, subtitle: next.subtitle }
+          : DEFAULT_SETTINGS;
+        setSettings(loaded);
+        onSettingsChange(loaded);
+        showToast("삭제했어요");
+      } else {
+        const data = await res.json().catch(() => null);
+        showToast(extractErrorMessage(data, "삭제하지 못했어요. 다시 시도해 주세요."), "error");
+      }
+    } catch {
+      showToast("삭제하지 못했어요. 다시 시도해 주세요.", "error");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const cancelNameDialog = () => {
+    setNameDialogMode(null);
+    setNameInput("");
   };
 
   return (
@@ -617,6 +877,137 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
 
         {/* Expanded content */}
         <Collapse in={expanded} timeout={250}>
+          {/* 스타일 템플릿 영역 */}
+          <Box sx={{ borderTop: "1.5px solid #f2f4f8", px: 3, py: 2.5 }}>
+            <Typography
+              sx={{
+                fontSize: 13,
+                fontWeight: 700,
+                color: "#1976d2",
+                letterSpacing: 0.2,
+                textTransform: "uppercase",
+                mb: 1,
+              }}
+            >
+              스타일 템플릿
+            </Typography>
+
+            {templatesLoading ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.5 }}>
+                <CircularProgress size={16} />
+                <Typography sx={{ fontSize: 12, color: "#888" }}>
+                  템플릿을 불러오는 중이에요
+                </Typography>
+              </Box>
+            ) : templates.length === 0 ? (
+              <Typography sx={{ fontSize: 12, color: "#888" }}>
+                아직 저장된 템플릿이 없어요. 편집 후 &apos;새 템플릿으로 저장&apos;을 눌러보세요.
+              </Typography>
+            ) : (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                {templates.map((t) => (
+                  <TemplateChip
+                    key={t.id}
+                    template={t}
+                    selected={t.id === selectedTemplateId}
+                    onClick={() => handleSelectTemplate(t)}
+                  />
+                ))}
+              </Box>
+            )}
+
+            {/* 액션 버튼 또는 이름 입력/삭제 확인 폼 */}
+            {nameDialogMode ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5, flexWrap: "wrap" }}>
+                <TextField
+                  size="small"
+                  autoFocus
+                  value={nameInput}
+                  onChange={(e) => setNameInput(e.target.value)}
+                  placeholder="템플릿 이름"
+                  inputProps={{ maxLength: 20 }}
+                  sx={{ maxWidth: 220 }}
+                />
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={!nameInput.trim() || actionLoading !== null}
+                  onClick={nameDialogMode === "create" ? handleCreateConfirm : handleRenameConfirm}
+                >
+                  {actionLoading === "create" || actionLoading === "rename" ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : (
+                    "확인"
+                  )}
+                </Button>
+                <Button size="small" onClick={cancelNameDialog} disabled={actionLoading !== null}>
+                  취소
+                </Button>
+              </Box>
+            ) : deleteConfirming ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5, flexWrap: "wrap" }}>
+                <Typography sx={{ fontSize: 12.5, color: "#d32f2f" }}>
+                  &apos;{selectedTemplate?.name}&apos; 템플릿을 삭제할까요?
+                </Typography>
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="error"
+                  onClick={handleDelete}
+                  disabled={actionLoading !== null}
+                >
+                  {actionLoading === "delete" ? <CircularProgress size={16} color="inherit" /> : "삭제"}
+                </Button>
+                <Button size="small" onClick={() => setDeleteConfirming(false)} disabled={actionLoading !== null}>
+                  취소
+                </Button>
+              </Box>
+            ) : (
+              <>
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.5 }}>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={!selectedTemplateId || !hasChanged || actionLoading !== null}
+                    onClick={handleSaveCurrent}
+                  >
+                    {actionLoading === "save" ? <CircularProgress size={16} /> : "현재 편집값 저장"}
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    disabled={templates.length >= MAX_TEMPLATES || actionLoading !== null}
+                    onClick={openCreate}
+                  >
+                    새 템플릿으로 저장
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="text"
+                    disabled={!selectedTemplateId || actionLoading !== null}
+                    onClick={openRename}
+                  >
+                    이름 변경
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="text"
+                    color="error"
+                    disabled={!selectedTemplateId || templates.length <= 1 || actionLoading !== null}
+                    onClick={() => setDeleteConfirming(true)}
+                  >
+                    삭제
+                  </Button>
+                </Box>
+                {templates.length >= MAX_TEMPLATES && (
+                  <Typography sx={{ fontSize: 11, color: "#d32f2f", mt: 0.5 }}>
+                    템플릿은 최대 5개까지 저장할 수 있어요
+                  </Typography>
+                )}
+              </>
+            )}
+          </Box>
+
           <Box
             sx={{
               borderTop: "1.5px solid #f2f4f8",
@@ -655,11 +1046,11 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
                 onOpenFontPicker={() => handleOpenPicker("subtitle")}
               />
 
-              {/* Reset button */}
+              {/* Revert button — 선택된 템플릿(또는 기본값)으로 되돌리기 */}
               {hasChanged && (
                 <Box sx={{ mt: 3 }}>
                   <Typography
-                    onClick={handleReset}
+                    onClick={handleRevert}
                     sx={{
                       fontSize: 13,
                       color: "text.secondary",
@@ -669,7 +1060,7 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
                       "&:hover": { color: "#1976d2" },
                     }}
                   >
-                    기본값으로 초기화
+                    변경 내용 되돌리기
                   </Typography>
                 </Box>
               )}
@@ -696,19 +1087,19 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
         onClose={() => setPickerOpen(false)}
       />
 
-      {/* Save toast */}
+      {/* Action toast */}
       <Snackbar
-        open={toastOpen}
-        autoHideDuration={1500}
-        onClose={() => setToastOpen(false)}
+        open={toast.open}
+        autoHideDuration={2000}
+        onClose={() => setToast((prev) => ({ ...prev, open: false }))}
         anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       >
         <Alert
-          onClose={() => setToastOpen(false)}
-          severity="success"
+          onClose={() => setToast((prev) => ({ ...prev, open: false }))}
+          severity={toast.severity}
           sx={{ width: "100%" }}
         >
-          저장됐어요
+          {toast.message}
         </Alert>
       </Snackbar>
 

--- a/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
+++ b/auto_video_create_front/src/app/components/SubtitleStyleEditor.tsx
@@ -544,6 +544,8 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
   const [nameDialogMode, setNameDialogMode] = useState<NameDialogMode>(null);
   const [nameInput, setNameInput] = useState("");
   const [deleteConfirming, setDeleteConfirming] = useState(false);
+  // 미저장 편집이 있는 상태에서 다른 템플릿으로 전환 시도 시, 확인 대기 중인 대상 템플릿.
+  const [pendingSwitch, setPendingSwitch] = useState<SubtitleTemplate | null>(null);
   const [actionLoading, setActionLoading] = useState<ActionKind>(null);
 
   const [toast, setToast] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({
@@ -652,13 +654,24 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
 
   // ── 템플릿 선택 ──────────────────────────────────────────────────────────
 
-  const handleSelectTemplate = (template: SubtitleTemplate) => {
+  const doSelectTemplate = (template: SubtitleTemplate) => {
     setSelectedTemplateId(template.id);
     const loaded: SubtitleSettings = { title: template.title, subtitle: template.subtitle };
     setSettings(loaded);
     onSettingsChange(loaded);
     setNameDialogMode(null);
     setDeleteConfirming(false);
+    setPendingSwitch(null);
+  };
+
+  const handleSelectTemplate = (template: SubtitleTemplate) => {
+    if (template.id === selectedTemplateId) return;
+    // 미저장 편집이 있으면 바로 덮어쓰지 않고 전환 확인을 먼저 받는다 (편집 유실 방지).
+    if (hasChanged) {
+      setPendingSwitch(template);
+      return;
+    }
+    doSelectTemplate(template);
   };
 
   // ── 액션: 현재 편집값 저장 (선택된 템플릿에 PUT) ────────────────────────
@@ -916,8 +929,26 @@ export default function SubtitleStyleEditor({ onSettingsChange }: SubtitleStyleE
               </Box>
             )}
 
-            {/* 액션 버튼 또는 이름 입력/삭제 확인 폼 */}
-            {nameDialogMode ? (
+            {/* 액션 버튼 또는 전환 경고/이름 입력/삭제 확인 폼 */}
+            {pendingSwitch ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5, flexWrap: "wrap" }}>
+                <Typography sx={{ fontSize: 12.5, color: "#d32f2f" }}>
+                  저장하지 않은 변경이 있어요. &apos;{pendingSwitch.name}&apos;(으)로 전환하면 변경 내용이 사라져요.
+                </Typography>
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="error"
+                  onClick={() => doSelectTemplate(pendingSwitch)}
+                  disabled={actionLoading !== null}
+                >
+                  전환
+                </Button>
+                <Button size="small" onClick={() => setPendingSwitch(null)} disabled={actionLoading !== null}>
+                  취소
+                </Button>
+              </Box>
+            ) : nameDialogMode ? (
               <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1.5, flexWrap: "wrap" }}>
                 <TextField
                   size="small"

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from services.blog_shorts import extract_blog_content, get_blog_media_and_scripts
 from services.summarize import summarize_for_shorts_sets
@@ -13,7 +14,15 @@ from services.subtitle_settings_service import (
     get_subtitle_settings,
     save_subtitle_settings,
     validate_subtitle_settings,
+    validate_text_style,
     apply_subtitle_settings_to_variables,
+    # feat/style-templates: 이름 붙인 템플릿 CRUD (최대 5개)
+    get_subtitle_templates,
+    create_subtitle_template,
+    update_subtitle_template,
+    delete_subtitle_template,
+    TemplateLimitReachedError,
+    TemplateNotFoundError,
 )
 from crawler.dispatcher import UnsupportedPlatformError
 from utils.s3_utils import load_json_from_s3
@@ -209,6 +218,19 @@ class SubtitleSettingsModel(BaseModel):
 class SubtitleSettingsRequest(BaseModel):
     title: TextStyleModel
     subtitle: TextStyleModel
+
+
+# feat/style-templates: 이름 붙인 템플릿(최대 5개) 요청 모델
+class SubtitleTemplateCreateRequest(BaseModel):
+    name: str
+    title: TextStyleModel
+    subtitle: TextStyleModel
+
+
+class SubtitleTemplateUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    title: Optional[TextStyleModel] = None
+    subtitle: Optional[TextStyleModel] = None
 
 
 # --- 최종 영상 생성 API ---
@@ -431,3 +453,184 @@ def put_subtitle_settings_endpoint(
         print(f"[put_subtitle_settings 에러] user={user_id} {e}")
         traceback.print_exc()
         raise HTTPException(status_code=500, detail="설정을 저장할 수 없습니다.")
+
+
+# ─────────────────────────────────────────────
+# feat/style-templates 신규 엔드포인트
+#
+# 계정당 단일 subtitle_settings 를 대체하는 것이 아니라, 이름 붙인 템플릿
+# 최대 5개(subtitle_templates)를 저장/재사용할 수 있게 하는 편의 계층.
+# generate-video 는 변경 없음 — FE 가 선택한 템플릿의 {title, subtitle} 을
+# 그대로 subtitle_settings 로 보낸다.
+#
+# 기존 GET/PUT /subtitle-settings 엔드포인트는 하위 호환을 위해 그대로 유지한다
+# (제거하지 않음). 신규 FE 는 아래 CRUD 를 사용한다.
+# ─────────────────────────────────────────────
+
+@router.get("/subtitle-templates")
+def get_subtitle_templates_endpoint(user=Depends(require_active_subscription)):
+    """
+    GET /api/blog/subtitle-templates
+
+    이름 붙인 자막 스타일 템플릿 목록 조회 (계정당 최대 5개).
+    레거시 단일 subtitle_settings 만 있는 계정은 자동 마이그레이션되어
+    [{id, name:"템플릿 1", title, subtitle}] 형태로 반환된다(영속화는 다음
+    저장/수정/삭제 시점에 lazy 하게 이뤄짐 — 조회만으로는 S3 에 쓰지 않음).
+
+    응답: { "templates": [{id, name, title, subtitle}, ...] }
+    """
+    user_id = user["id"]
+    try:
+        templates = get_subtitle_templates(user_id)
+        return {"templates": templates}
+    except Exception as e:
+        print(f"[get_subtitle_templates 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="템플릿 목록을 불러올 수 없습니다.")
+
+
+@router.post("/subtitle-templates")
+def create_subtitle_template_endpoint(
+    req: SubtitleTemplateCreateRequest,
+    user=Depends(require_active_subscription),
+):
+    """
+    POST /api/blog/subtitle-templates
+
+    신규 이름 붙인 자막 스타일 템플릿 생성. 계정당 최대 5개.
+    이미 5개면 400 + {"error_code": "template_limit_reached"}.
+    스타일 검증 실패 시 400 + 메시지.
+
+    응답(성공): 생성된 템플릿 {id, name, title, subtitle}
+    """
+    user_id = user["id"]
+
+    if not req.name or not req.name.strip():
+        raise HTTPException(status_code=400, detail="템플릿 이름은 비어있을 수 없습니다.")
+
+    style_dict = {"title": req.title.model_dump(), "subtitle": req.subtitle.model_dump()}
+
+    try:
+        allowed_families = get_allowed_font_families()
+    except Exception:
+        allowed_families = set()
+        print("[create_subtitle_template] font 허용 목록 로드 실패 — 검증 완화")
+
+    errors = validate_subtitle_settings(style_dict, allowed_families)
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail="유효하지 않은 설정값입니다.: " + " | ".join(errors),
+        )
+
+    try:
+        template = create_subtitle_template(
+            user_id, req.name.strip(), style_dict["title"], style_dict["subtitle"]
+        )
+        return template
+    except TemplateLimitReachedError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "template_limit_reached",
+                "message": "템플릿은 최대 5개까지 저장할 수 있습니다.",
+            },
+        )
+    except LookupError:
+        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[create_subtitle_template 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="템플릿을 생성할 수 없습니다.")
+
+
+@router.put("/subtitle-templates/{template_id}")
+def update_subtitle_template_endpoint(
+    template_id: str,
+    req: SubtitleTemplateUpdateRequest,
+    user=Depends(require_active_subscription),
+):
+    """
+    PUT /api/blog/subtitle-templates/{template_id}
+
+    기존 템플릿 부분 수정 — name/title/subtitle 중 요청에 포함된(None 이 아닌)
+    필드만 반영. 없는 template_id 면 404. 검증 실패 시 400.
+
+    응답(성공): 수정된 템플릿 {id, name, title, subtitle}
+    """
+    user_id = user["id"]
+
+    if req.name is not None and not req.name.strip():
+        raise HTTPException(status_code=400, detail="템플릿 이름은 비어있을 수 없습니다.")
+
+    title_dict = req.title.model_dump() if req.title is not None else None
+    subtitle_dict = req.subtitle.model_dump() if req.subtitle is not None else None
+
+    if title_dict is not None or subtitle_dict is not None:
+        try:
+            allowed_families = get_allowed_font_families()
+        except Exception:
+            allowed_families = set()
+            print("[update_subtitle_template] font 허용 목록 로드 실패 — 검증 완화")
+
+        errors: List[str] = []
+        if title_dict is not None:
+            errors.extend(f"[title] {e}" for e in validate_text_style(title_dict, allowed_families))
+        if subtitle_dict is not None:
+            errors.extend(f"[subtitle] {e}" for e in validate_text_style(subtitle_dict, allowed_families))
+
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail="유효하지 않은 설정값입니다.: " + " | ".join(errors),
+            )
+
+    try:
+        template = update_subtitle_template(
+            user_id,
+            template_id,
+            name=req.name.strip() if req.name is not None else None,
+            title=title_dict,
+            subtitle=subtitle_dict,
+        )
+        return template
+    except TemplateNotFoundError:
+        raise HTTPException(status_code=404, detail="템플릿을 찾을 수 없습니다.")
+    except LookupError:
+        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[update_subtitle_template 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="템플릿을 수정할 수 없습니다.")
+
+
+@router.delete("/subtitle-templates/{template_id}")
+def delete_subtitle_template_endpoint(
+    template_id: str,
+    user=Depends(require_active_subscription),
+):
+    """
+    DELETE /api/blog/subtitle-templates/{template_id}
+
+    템플릿 삭제. 없으면 404.
+
+    응답(성공): { "status": "success" }
+    """
+    user_id = user["id"]
+    try:
+        delete_subtitle_template(user_id, template_id)
+        return {"status": "success"}
+    except TemplateNotFoundError:
+        raise HTTPException(status_code=404, detail="템플릿을 찾을 수 없습니다.")
+    except LookupError:
+        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[delete_subtitle_template 에러] user={user_id} {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail="템플릿을 삭제할 수 없습니다.")

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -23,6 +23,7 @@ from services.subtitle_settings_service import (
     delete_subtitle_template,
     TemplateLimitReachedError,
     TemplateNotFoundError,
+    LastTemplateError,
 )
 from crawler.dispatcher import UnsupportedPlatformError
 from utils.s3_utils import load_json_from_s3
@@ -624,6 +625,14 @@ def delete_subtitle_template_endpoint(
     try:
         delete_subtitle_template(user_id, template_id)
         return {"status": "success"}
+    except LastTemplateError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error_code": "cannot_delete_last_template",
+                "message": "마지막 템플릿은 삭제할 수 없어요.",
+            },
+        )
     except TemplateNotFoundError:
         raise HTTPException(status_code=404, detail="템플릿을 찾을 수 없습니다.")
     except LookupError:

--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -1,15 +1,20 @@
 """
-subtitle_settings_service.py — cycle-3 신규
+subtitle_settings_service.py — cycle-3 신규, feat/style-templates 확장
 
 사용자별 자막 스타일 설정을 S3 users.json 에서 읽고 쓴다.
 
 data-model.md §1~§3 스키마 준수.
 기존 deduct_credits / account_service 패턴(S3 read-modify-write)과 동일 방식.
+
+feat/style-templates: 계정당 단일 subtitle_settings 를 이름 붙인 템플릿 최대 5개
+(subtitle_templates)로 확장. 레거시 단일 subtitle_settings 만 있는 계정은 읽을 때
+자동 마이그레이션(첫 조회 시 변환, 다음 저장 시점에 영속화 — lazy).
 """
 
 import json
 import logging
 import re
+import uuid
 from typing import Optional
 
 import boto3
@@ -54,7 +59,22 @@ DEFAULT_SUBTITLE_SETTINGS: dict = {
     "fill_color": "#ffffff",
 }
 
+# feat/style-templates: 계정당 최대 저장 가능한 이름 붙인 템플릿 개수
+MAX_SUBTITLE_TEMPLATES = 5
+
 _s3 = boto3.client("s3", region_name="ap-northeast-2")
+
+
+# ─────────────────────────────────────────────
+# feat/style-templates 전용 예외
+# ─────────────────────────────────────────────
+
+class TemplateLimitReachedError(Exception):
+    """계정당 템플릿 개수(MAX_SUBTITLE_TEMPLATES)를 초과해 생성 시도할 때 발생."""
+
+
+class TemplateNotFoundError(Exception):
+    """지정한 template_id 가 사용자의 템플릿 목록에 없을 때 발생."""
 
 
 # ─────────────────────────────────────────────
@@ -85,6 +105,15 @@ def _validate_text_style(style: dict, allowed_families: set[str]) -> list[str]:
         errors.append(f"fill_color 는 #RRGGBB 형식이어야 합니다. 받은 값: {fill_color!r}")
 
     return errors
+
+
+def validate_text_style(style: dict, allowed_families: set[str]) -> list[str]:
+    """
+    단일 TextStyle(title 또는 subtitle 섹션 하나) 검증 공개 wrapper.
+    feat/style-templates PUT(부분 수정) 처럼 섹션 하나만 검증해야 할 때 사용.
+    반환: 오류 메시지 목록 (빈 목록 = 통과).
+    """
+    return _validate_text_style(style, allowed_families)
 
 
 def validate_subtitle_settings(settings: dict, allowed_families: set[str]) -> list[str]:
@@ -156,6 +185,222 @@ def save_subtitle_settings(user_id: str, settings: dict) -> bool:
         return True
     except Exception as e:
         logger.error(f"[subtitle_settings] SAVE 실패 user={user_id}: {e}")
+        raise
+
+
+# ─────────────────────────────────────────────
+# feat/style-templates — 이름 붙인 템플릿 CRUD (최대 MAX_SUBTITLE_TEMPLATES 개)
+# ─────────────────────────────────────────────
+
+# 마이그레이션된 legacy 템플릿의 id 를 만들 때 쓰는 고정 네임스페이스.
+# uuid.uuid5 는 (namespace, name) 이 같으면 항상 동일한 UUID 를 반환한다 — 이 성질을
+# 이용해, 아직 영속화되지 않은(=lazy) 상태에서 GET 을 여러 번 호출해도 같은 id 가
+# 나오도록 보장한다. 만약 매번 uuid4() 로 랜덤 생성하면 "GET 으로 id 확인 → 그 id 로
+# DELETE/PUT" 같은 정상 흐름이 두 번째 요청에서 404 로 깨진다(실제로 테스트에서 발견).
+_LEGACY_TEMPLATE_ID_NAMESPACE = uuid.UUID("6a3f6c1e-6b8b-4b8b-9b0a-3a5b6c7d8e9f")
+
+
+def _migrate_legacy_templates(user: dict) -> list[dict]:
+    """
+    user dict 로부터 subtitle_templates 리스트를 얻는다.
+
+    - user["subtitle_templates"] 가 이미 있으면 그대로 반환(정상 경로).
+    - 없고 legacy user["subtitle_settings"](단일 dict) 만 있으면
+      [{id, name:"템플릿 1", title, subtitle}] 로 변환해 반환(마이그레이션).
+      이 반환값은 in-memory 변환일 뿐 여기서 S3 에 저장하지 않는다(lazy 영속화 —
+      다음 CRUD 저장 시점에 실제 write 가 일어남). id 는 user_id 기반 결정적(uuid5)
+      값이라, 영속화 전에 GET 을 여러 번 호출해도 항상 같은 id 가 나온다.
+    - 둘 다 없으면 빈 리스트.
+    """
+    templates = user.get("subtitle_templates")
+    if templates is not None:
+        return templates
+
+    legacy = user.get("subtitle_settings")
+    if isinstance(legacy, dict) and isinstance(legacy.get("title"), dict) and isinstance(legacy.get("subtitle"), dict):
+        user_id = user.get("id", "")
+        deterministic_id = str(uuid.uuid5(_LEGACY_TEMPLATE_ID_NAMESPACE, f"legacy-subtitle-settings-{user_id}"))
+        return [
+            {
+                "id": deterministic_id,
+                "name": "템플릿 1",
+                "title": legacy["title"],
+                "subtitle": legacy["subtitle"],
+            }
+        ]
+
+    return []
+
+
+def get_subtitle_templates(user_id: str) -> list[dict]:
+    """
+    users.json 에서 user_id 에 해당하는 subtitle_templates 목록 반환.
+    레거시 단일 subtitle_settings 만 있으면 마이그레이션된 값을 반환(영속화 안 함).
+    사용자 없으면 빈 리스트.
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        for user in users:
+            if user["id"] == user_id:
+                templates = _migrate_legacy_templates(user)
+                logger.info(
+                    f"[subtitle_templates] GET user={user_id} count={len(templates)}"
+                )
+                return templates
+        logger.warning(f"[subtitle_templates] GET user={user_id} — 사용자 없음")
+        return []
+    except Exception as e:
+        logger.error(f"[subtitle_templates] GET 실패 user={user_id}: {e}")
+        raise
+
+
+def create_subtitle_template(user_id: str, name: str, title: dict, subtitle: dict) -> dict:
+    """
+    신규 이름 붙인 템플릿 생성.
+
+    - 사용자 없으면 LookupError.
+    - 기존 템플릿(마이그레이션 포함)이 이미 MAX_SUBTITLE_TEMPLATES 개면 TemplateLimitReachedError.
+    - 성공 시 생성된 템플릿 dict({id, name, title, subtitle}) 반환.
+    - S3 read-modify-write 패턴 (기존 save_subtitle_settings 와 동일 방식).
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        target_user = None
+        for user in users:
+            if user["id"] == user_id:
+                target_user = user
+                break
+
+        if target_user is None:
+            logger.warning(f"[subtitle_templates] CREATE user={user_id} — 사용자 없음")
+            raise LookupError(f"사용자를 찾을 수 없습니다: {user_id}")
+
+        templates = _migrate_legacy_templates(target_user)
+        if len(templates) >= MAX_SUBTITLE_TEMPLATES:
+            raise TemplateLimitReachedError(
+                f"템플릿은 최대 {MAX_SUBTITLE_TEMPLATES}개까지 저장할 수 있습니다."
+            )
+
+        new_template = {
+            "id": str(uuid.uuid4()),
+            "name": name,
+            "title": title,
+            "subtitle": subtitle,
+        }
+        target_user["subtitle_templates"] = templates + [new_template]
+
+        _s3.put_object(
+            Bucket=BUCKET_USERS,
+            Key=KEY_USERS,
+            Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+        )
+        logger.info(f"[subtitle_templates] CREATE user={user_id} template_id={new_template['id']} 완료")
+        return new_template
+    except (LookupError, TemplateLimitReachedError):
+        raise
+    except Exception as e:
+        logger.error(f"[subtitle_templates] CREATE 실패 user={user_id}: {e}")
+        raise
+
+
+def update_subtitle_template(
+    user_id: str,
+    template_id: str,
+    name: Optional[str] = None,
+    title: Optional[dict] = None,
+    subtitle: Optional[dict] = None,
+) -> dict:
+    """
+    기존 템플릿 부분 수정 (name/title/subtitle 중 전달된(None 이 아닌) 값만 반영).
+
+    - 사용자 없으면 LookupError.
+    - template_id 가 목록에 없으면 TemplateNotFoundError.
+    - 성공 시 수정된 템플릿 dict 반환.
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        target_user = None
+        for user in users:
+            if user["id"] == user_id:
+                target_user = user
+                break
+
+        if target_user is None:
+            logger.warning(f"[subtitle_templates] UPDATE user={user_id} — 사용자 없음")
+            raise LookupError(f"사용자를 찾을 수 없습니다: {user_id}")
+
+        templates = _migrate_legacy_templates(target_user)
+        updated_template = None
+        new_templates = []
+        for tpl in templates:
+            if tpl.get("id") == template_id:
+                if name is not None:
+                    tpl = {**tpl, "name": name}
+                if title is not None:
+                    tpl = {**tpl, "title": title}
+                if subtitle is not None:
+                    tpl = {**tpl, "subtitle": subtitle}
+                updated_template = tpl
+            new_templates.append(tpl)
+
+        if updated_template is None:
+            logger.warning(f"[subtitle_templates] UPDATE user={user_id} template_id={template_id} — 템플릿 없음")
+            raise TemplateNotFoundError(f"템플릿을 찾을 수 없습니다: {template_id}")
+
+        target_user["subtitle_templates"] = new_templates
+
+        _s3.put_object(
+            Bucket=BUCKET_USERS,
+            Key=KEY_USERS,
+            Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+        )
+        logger.info(f"[subtitle_templates] UPDATE user={user_id} template_id={template_id} 완료")
+        return updated_template
+    except (LookupError, TemplateNotFoundError):
+        raise
+    except Exception as e:
+        logger.error(f"[subtitle_templates] UPDATE 실패 user={user_id} template_id={template_id}: {e}")
+        raise
+
+
+def delete_subtitle_template(user_id: str, template_id: str) -> None:
+    """
+    템플릿 삭제.
+
+    - 사용자 없으면 LookupError.
+    - template_id 가 목록에 없으면 TemplateNotFoundError.
+    """
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        target_user = None
+        for user in users:
+            if user["id"] == user_id:
+                target_user = user
+                break
+
+        if target_user is None:
+            logger.warning(f"[subtitle_templates] DELETE user={user_id} — 사용자 없음")
+            raise LookupError(f"사용자를 찾을 수 없습니다: {user_id}")
+
+        templates = _migrate_legacy_templates(target_user)
+        new_templates = [tpl for tpl in templates if tpl.get("id") != template_id]
+
+        if len(new_templates) == len(templates):
+            logger.warning(f"[subtitle_templates] DELETE user={user_id} template_id={template_id} — 템플릿 없음")
+            raise TemplateNotFoundError(f"템플릿을 찾을 수 없습니다: {template_id}")
+
+        target_user["subtitle_templates"] = new_templates
+
+        _s3.put_object(
+            Bucket=BUCKET_USERS,
+            Key=KEY_USERS,
+            Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+        )
+        logger.info(f"[subtitle_templates] DELETE user={user_id} template_id={template_id} 완료")
+    except (LookupError, TemplateNotFoundError):
+        raise
+    except Exception as e:
+        logger.error(f"[subtitle_templates] DELETE 실패 user={user_id} template_id={template_id}: {e}")
         raise
 
 

--- a/auto_video_create_server/services/subtitle_settings_service.py
+++ b/auto_video_create_server/services/subtitle_settings_service.py
@@ -77,6 +77,10 @@ class TemplateNotFoundError(Exception):
     """지정한 template_id 가 사용자의 템플릿 목록에 없을 때 발생."""
 
 
+class LastTemplateError(Exception):
+    """마지막 남은 1개 템플릿을 삭제하려 할 때 발생 (최소 1개 유지)."""
+
+
 # ─────────────────────────────────────────────
 # 유효성 검증 헬퍼
 # ─────────────────────────────────────────────
@@ -389,6 +393,12 @@ def delete_subtitle_template(user_id: str, template_id: str) -> None:
             logger.warning(f"[subtitle_templates] DELETE user={user_id} template_id={template_id} — 템플릿 없음")
             raise TemplateNotFoundError(f"템플릿을 찾을 수 없습니다: {template_id}")
 
+        # 최소 1개 템플릿 유지 — 마지막 남은 템플릿 삭제 방지 (서버측 강제).
+        # FE 도 버튼을 비활성화하지만, 동시 요청/다른 클라이언트 경로에서 0개가 되는 것을 막는다.
+        if len(new_templates) == 0:
+            logger.warning(f"[subtitle_templates] DELETE user={user_id} template_id={template_id} — 마지막 템플릿 삭제 거부")
+            raise LastTemplateError("마지막 템플릿은 삭제할 수 없습니다.")
+
         target_user["subtitle_templates"] = new_templates
 
         _s3.put_object(
@@ -397,7 +407,7 @@ def delete_subtitle_template(user_id: str, template_id: str) -> None:
             Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
         )
         logger.info(f"[subtitle_templates] DELETE user={user_id} template_id={template_id} 완료")
-    except (LookupError, TemplateNotFoundError):
+    except (LookupError, TemplateNotFoundError, LastTemplateError):
         raise
     except Exception as e:
         logger.error(f"[subtitle_templates] DELETE 실패 user={user_id} template_id={template_id}: {e}")

--- a/auto_video_create_server/tests/test_style_templates.py
+++ b/auto_video_create_server/tests/test_style_templates.py
@@ -1,0 +1,308 @@
+"""
+test_style_templates.py — feat/style-templates 단위 테스트
+
+계정당 단일 subtitle_settings 를 이름 붙인 템플릿 최대 5개(subtitle_templates)로
+확장하는 기능의 순수 로직 검증. S3 는 전부 mock 처리 (외부 의존성 없음).
+pytest 없이 stdlib unittest 사용 (기존 test_cycle3_subtitle.py 와 동일 관행).
+"""
+
+import copy
+import json
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+# 서버 루트를 sys.path 에 추가
+_SERVER_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SERVER_ROOT not in sys.path:
+    sys.path.insert(0, _SERVER_ROOT)
+
+
+def _users_fixture():
+    """users.json mock 데이터 — 각 테스트에서 deepcopy 해서 사용."""
+    return [
+        {
+            "id": "legacy_user",
+            "pw": "pw",
+            "subscription_start": "2020-01-01",
+            "subscription_end": "2099-01-01",
+            "credits": 1000,
+            # subtitle_templates 없음, legacy 단일 subtitle_settings 만 있음
+            "subtitle_settings": {
+                "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+                "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+            },
+        },
+        {
+            "id": "no_settings_user",
+            "pw": "pw",
+            "subscription_start": "2020-01-01",
+            "subscription_end": "2099-01-01",
+            "credits": 1000,
+            # subtitle_settings 도, subtitle_templates 도 없음
+        },
+        {
+            "id": "templated_user",
+            "pw": "pw",
+            "subscription_start": "2020-01-01",
+            "subscription_end": "2099-01-01",
+            "credits": 1000,
+            "subtitle_templates": [
+                {
+                    "id": "tpl-1",
+                    "name": "기본",
+                    "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+                    "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+                }
+            ],
+            # 레거시 필드가 남아있어도 subtitle_templates 가 있으면 그쪽을 신뢰
+            "subtitle_settings": {
+                "title": {"font_family": "Do Hyeon", "font_size": "L", "fill_color": "#000000"},
+                "subtitle": {"font_family": "Do Hyeon", "font_size": "L", "fill_color": "#000000"},
+            },
+        },
+        {
+            "id": "five_templates_user",
+            "pw": "pw",
+            "subscription_start": "2020-01-01",
+            "subscription_end": "2099-01-01",
+            "credits": 1000,
+            "subtitle_templates": [
+                {
+                    "id": f"tpl-{i}",
+                    "name": f"템플릿 {i}",
+                    "title": {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+                    "subtitle": {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+                }
+                for i in range(5)
+            ],
+        },
+    ]
+
+
+class StyleTemplatesTestCase(unittest.TestCase):
+    """공통 mock 셋업: load_json_from_s3 / _s3.put_object 를 patch."""
+
+    def setUp(self):
+        from services import subtitle_settings_service as svc
+
+        self.svc = svc
+        self._users = _users_fixture()
+
+        self.load_patcher = patch.object(svc, "load_json_from_s3", return_value=copy.deepcopy(self._users))
+        self.mock_load = self.load_patcher.start()
+        self.addCleanup(self.load_patcher.stop)
+
+        self.s3_patcher = patch.object(svc, "_s3", MagicMock())
+        self.mock_s3 = self.s3_patcher.start()
+        self.addCleanup(self.s3_patcher.stop)
+
+    def _put_object_body(self):
+        """put_object 호출 시 전달된 Body 를 파싱해 users 리스트로 반환."""
+        _, kwargs = self.mock_s3.put_object.call_args
+        return json.loads(kwargs["Body"].decode("utf-8"))
+
+    def _find_user(self, users, user_id):
+        return next(u for u in users if u["id"] == user_id)
+
+
+# ─────────────────────────────────────────────
+# 마이그레이션 (읽기 시)
+# ─────────────────────────────────────────────
+
+class TestMigration(StyleTemplatesTestCase):
+
+    def test_legacy_user_migrated_on_get(self):
+        """subtitle_templates 없고 legacy subtitle_settings 만 있으면 1개짜리 템플릿으로 변환."""
+        templates = self.svc.get_subtitle_templates("legacy_user")
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0]["name"], "템플릿 1")
+        self.assertIn("id", templates[0])
+        self.assertEqual(templates[0]["title"]["font_family"], "Black Han Sans")
+        self.assertEqual(templates[0]["subtitle"]["font_family"], "Noto Sans KR")
+
+    def test_legacy_migration_not_persisted_on_get(self):
+        """GET 만으로는 S3 에 쓰지 않는다 (lazy 영속화)."""
+        self.svc.get_subtitle_templates("legacy_user")
+        self.mock_s3.put_object.assert_not_called()
+
+    def test_no_settings_user_returns_empty_list(self):
+        """subtitle_settings 도 subtitle_templates 도 없으면 빈 리스트."""
+        templates = self.svc.get_subtitle_templates("no_settings_user")
+        self.assertEqual(templates, [])
+
+    def test_templated_user_ignores_legacy_field(self):
+        """subtitle_templates 가 이미 있으면 legacy subtitle_settings 는 무시."""
+        templates = self.svc.get_subtitle_templates("templated_user")
+        self.assertEqual(len(templates), 1)
+        self.assertEqual(templates[0]["id"], "tpl-1")
+        self.assertEqual(templates[0]["title"]["font_family"], "Black Han Sans")  # legacy(Do Hyeon) 아님
+
+    def test_unknown_user_returns_empty_list(self):
+        templates = self.svc.get_subtitle_templates("nonexistent_user")
+        self.assertEqual(templates, [])
+
+    def test_legacy_migration_persisted_lazily_on_next_create(self):
+        """마이그레이션은 다음 CRUD 저장 시점에 실제로 영속화된다."""
+        self.svc.create_subtitle_template(
+            "legacy_user",
+            "새 템플릿",
+            {"font_family": "Do Hyeon", "font_size": "S", "fill_color": "#111111"},
+            {"font_family": "Do Hyeon", "font_size": "S", "fill_color": "#111111"},
+        )
+        saved_users = self._put_object_body()
+        saved_user = self._find_user(saved_users, "legacy_user")
+        # 기존 legacy 값 1개(마이그레이션) + 신규 1개 = 2개가 영속화됨
+        self.assertEqual(len(saved_user["subtitle_templates"]), 2)
+        self.assertEqual(saved_user["subtitle_templates"][0]["name"], "템플릿 1")
+        self.assertEqual(saved_user["subtitle_templates"][1]["name"], "새 템플릿")
+
+
+# ─────────────────────────────────────────────
+# 생성 — 5개 제한
+# ─────────────────────────────────────────────
+
+class TestCreateSubtitleTemplate(StyleTemplatesTestCase):
+
+    def test_create_success_returns_template_with_id(self):
+        template = self.svc.create_subtitle_template(
+            "no_settings_user",
+            "내 스타일",
+            {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        )
+        self.assertEqual(template["name"], "내 스타일")
+        self.assertIn("id", template)
+        self.mock_s3.put_object.assert_called_once()
+
+    def test_create_persists_to_s3(self):
+        self.svc.create_subtitle_template(
+            "templated_user",
+            "두번째",
+            {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+            {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+        )
+        saved_users = self._put_object_body()
+        saved_user = self._find_user(saved_users, "templated_user")
+        self.assertEqual(len(saved_user["subtitle_templates"]), 2)
+
+    def test_create_rejects_when_limit_reached(self):
+        """이미 5개면 TemplateLimitReachedError."""
+        with self.assertRaises(self.svc.TemplateLimitReachedError):
+            self.svc.create_subtitle_template(
+                "five_templates_user",
+                "여섯번째",
+                {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+                {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+            )
+        self.mock_s3.put_object.assert_not_called()
+
+    def test_create_unknown_user_raises_lookup_error(self):
+        with self.assertRaises(LookupError):
+            self.svc.create_subtitle_template(
+                "nonexistent_user",
+                "이름",
+                {"font_family": "Black Han Sans", "font_size": "M", "fill_color": "#fff100"},
+                {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"},
+            )
+        self.mock_s3.put_object.assert_not_called()
+
+
+# ─────────────────────────────────────────────
+# 수정
+# ─────────────────────────────────────────────
+
+class TestUpdateSubtitleTemplate(StyleTemplatesTestCase):
+
+    def test_update_name_only(self):
+        updated = self.svc.update_subtitle_template("templated_user", "tpl-1", name="바뀐 이름")
+        self.assertEqual(updated["name"], "바뀐 이름")
+        # title/subtitle 은 유지
+        self.assertEqual(updated["title"]["font_family"], "Black Han Sans")
+
+    def test_update_title_only(self):
+        new_title = {"font_family": "Do Hyeon", "font_size": "L", "fill_color": "#222222"}
+        updated = self.svc.update_subtitle_template("templated_user", "tpl-1", title=new_title)
+        self.assertEqual(updated["title"], new_title)
+        self.assertEqual(updated["name"], "기본")  # 이름 유지
+
+    def test_update_persists_only_changed_template(self):
+        self.svc.update_subtitle_template("templated_user", "tpl-1", name="변경됨")
+        saved_users = self._put_object_body()
+        saved_user = self._find_user(saved_users, "templated_user")
+        self.assertEqual(saved_user["subtitle_templates"][0]["name"], "변경됨")
+
+    def test_update_missing_template_raises_not_found(self):
+        with self.assertRaises(self.svc.TemplateNotFoundError):
+            self.svc.update_subtitle_template("templated_user", "no-such-id", name="x")
+        self.mock_s3.put_object.assert_not_called()
+
+    def test_update_unknown_user_raises_lookup_error(self):
+        with self.assertRaises(LookupError):
+            self.svc.update_subtitle_template("nonexistent_user", "tpl-1", name="x")
+
+
+# ─────────────────────────────────────────────
+# 삭제
+# ─────────────────────────────────────────────
+
+class TestDeleteSubtitleTemplate(StyleTemplatesTestCase):
+
+    def test_delete_success(self):
+        self.svc.delete_subtitle_template("templated_user", "tpl-1")
+        saved_users = self._put_object_body()
+        saved_user = self._find_user(saved_users, "templated_user")
+        self.assertEqual(saved_user["subtitle_templates"], [])
+
+    def test_delete_missing_template_raises_not_found(self):
+        with self.assertRaises(self.svc.TemplateNotFoundError):
+            self.svc.delete_subtitle_template("templated_user", "no-such-id")
+        self.mock_s3.put_object.assert_not_called()
+
+    def test_delete_unknown_user_raises_lookup_error(self):
+        with self.assertRaises(LookupError):
+            self.svc.delete_subtitle_template("nonexistent_user", "tpl-1")
+
+    def test_delete_from_legacy_migrated_list(self):
+        """legacy 유저도 마이그레이션된 항목을 삭제할 수 있어야 함(lazy 영속화 확인 포함).
+
+        GET 과 DELETE 는 각각 별도로 load_json_from_s3 를 호출(=별도로 마이그레이션)
+        하므로, id 가 결정적(uuid5)이지 않으면 GET 에서 받은 id 로 DELETE 가 404 나는
+        회귀가 발생한다 — 이 테스트는 그 회귀를 방지한다.
+        """
+        templates = self.svc.get_subtitle_templates("legacy_user")
+        migrated_id = templates[0]["id"]
+
+        # 마이그레이션 id 는 GET 을 다시 호출해도 항상 동일해야 한다 (결정적 uuid5).
+        templates_again = self.svc.get_subtitle_templates("legacy_user")
+        self.assertEqual(templates_again[0]["id"], migrated_id)
+
+        self.svc.delete_subtitle_template("legacy_user", migrated_id)
+        saved_users = self._put_object_body()
+        saved_user = self._find_user(saved_users, "legacy_user")
+        self.assertEqual(saved_user["subtitle_templates"], [])
+
+
+# ─────────────────────────────────────────────
+# validate_text_style (부분 검증 공개 wrapper)
+# ─────────────────────────────────────────────
+
+class TestValidateTextStyle(unittest.TestCase):
+
+    def test_valid_style_no_errors(self):
+        from services.subtitle_settings_service import validate_text_style
+        style = {"font_family": "Noto Sans KR", "font_size": "M", "fill_color": "#ffffff"}
+        errors = validate_text_style(style, {"Noto Sans KR"})
+        self.assertEqual(errors, [])
+
+    def test_invalid_style_returns_errors(self):
+        from services.subtitle_settings_service import validate_text_style
+        style = {"font_family": "Noto Sans KR", "font_size": "XL", "fill_color": "notacolor"}
+        errors = validate_text_style(style, {"Noto Sans KR"})
+        self.assertTrue(any("font_size" in e for e in errors))
+        self.assertTrue(any("fill_color" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## VOC 반영 — 스타일 템플릿

유저 VOC: "폰트/색상을 템플릿1,2처럼 여러 개 이름 붙여 저장·재사용하고 싶다."

### 변경
- **BE**: users.json에 `subtitle_templates`(최대 5, `{id,name,title,subtitle}`) + CRUD 4개 엔드포인트(`GET/POST/PUT/DELETE /api/blog/subtitle-templates`). 기존 단일 `subtitle_settings` → "템플릿 1" 자동 마이그레이션(결정적 uuid5). generate-video 무변경. 단위 테스트 23개
- **FE**: SubtitleStyleEditor 안에 템플릿 선택기 + 저장/새로저장/이름변경/삭제. 기존 폰트·크기·색 편집 유지

### 결정 (PO)
- 마이그레이션: 기존 설정 = "템플릿 1" / 최대 5개, 유저 명명 / 자막 편집기 내부 UI / sprint-4와 독립

### 리뷰/QA 확인
- [ ] 에러 응답 형식 혼재(`template_limit_reached` top-level vs FastAPI `detail`) FE 정합 재확인
- [ ] 미저장 편집값으로 생성 시 동작(템플릿엔 안 남음) 의도 확인
- [ ] 실제 fetch E2E (Node 부재로 로컬 build/lint 미검증 → CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)