### PR TITLE
feat: 글 맥락 기반 이미지 자동 배정 (default 제안) — VOC-2

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -31,6 +31,28 @@ interface SectionMedia {
   isDefaultBackground?: boolean;
 }
 
+// VOC-2: extract-all 응답의 suggested_sections 원소 타입 (BE 계약)
+type SuggestedSection = { type: 'image'; url: string } | { type: 'default'; url: null };
+
+// VOC-2: BE 응답의 suggested_sections 를 방어적으로 파싱한다.
+// 형식이 계약과 조금이라도 다르면(구버전 BE 포함) null 을 반환해 기존 동작(빈 슬롯)으로 폴백한다.
+function parseSuggestedSections(raw: unknown, expectedLength: number): SuggestedSection[] | null {
+  if (!Array.isArray(raw) || expectedLength <= 0 || raw.length !== expectedLength) return null;
+  const parsed: SuggestedSection[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") return null;
+    const { type, url } = item as { type?: unknown; url?: unknown };
+    if (type === "image" && typeof url === "string" && url.length > 0) {
+      parsed.push({ type: "image", url });
+    } else if (type === "default" && (url === null || url === undefined)) {
+      parsed.push({ type: "default", url: null });
+    } else {
+      return null;
+    }
+  }
+  return parsed;
+}
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
 const getProxiedImageUrl = (url: string) => `/api/image-proxy?url=${encodeURIComponent(url)}`;
@@ -65,6 +87,10 @@ export default function Home() {
 
   // sectionMedia: 길이 5, 각 원소는 SectionMedia 또는 null
   const [sectionMedia, setSectionMedia] = useState<(SectionMedia|null)[]>([null, null, null, null, null]);
+
+  // VOC-2: extract-all 응답의 suggested_sections 로 자동 채워진 이미지 슬롯 수.
+  // 1개 이상일 때만 select 진입 안내 문구를 노출한다.
+  const [autoFilledImageCount, setAutoFilledImageCount] = useState(0);
 
   // GPT가 생성한 스크립트 수정 상태 (수정 중인 카드 인덱스 + 임시 텍스트)
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
@@ -164,6 +190,7 @@ export default function Home() {
     setVideoUrl(null);
     setGenerateError(null);
     setSectionMedia([null, null, null, null, null]);
+    setAutoFilledImageCount(0);
     setEditingIdx(null);
     setEditingText("");
     const controller = new AbortController();
@@ -179,19 +206,41 @@ export default function Home() {
       const data = await res.json();
       if (data.status === "success") {
         setMedia({ images: data.images, videos: data.videos, scripts: data.scripts, title: data.title });
-        setScripts((data.scripts || []).map((s: { script: string } | string) => typeof s === 'string' ? s : s.script));
+        const scriptList: string[] = (data.scripts || []).map((s: { script: string } | string) => typeof s === 'string' ? s : s.script);
+        setScripts(scriptList);
         setTitle(data.title || "");
-        // cycle-2: BE 가 default_slot_count 만큼 부족 슬롯을 알려주면 후반부를 AI 기본 배경으로 채움
-        const defaultCount: number = typeof data.default_slot_count === 'number' ? data.default_slot_count : 0;
-        if (defaultCount > 0) {
-          setSectionMedia(prev => {
-            const updated = [...prev];
-            const start = Math.max(0, 5 - defaultCount);
-            for (let i = start; i < 5; i++) {
-              updated[i] = { type: 'default', url: null, isDefaultBackground: true };
+
+        // VOC-2: extract-all 응답의 suggested_sections 로 sectionMedia 초기값을 자동 채움 (default 제안, 강제 아님).
+        // 형식이 계약과 다르면(필드 없음/구버전 BE 포함) null 반환 → 기존 default_slot_count 폴백 동작 유지.
+        const suggested = parseSuggestedSections(data.suggested_sections, scriptList.length);
+        if (suggested) {
+          const filled: (SectionMedia | null)[] = [null, null, null, null, null];
+          let imageCount = 0;
+          suggested.forEach((item, i) => {
+            if (i >= filled.length) return;
+            if (item.type === 'image') {
+              filled[i] = { type: 'image', url: item.url };
+              imageCount++;
+            } else {
+              filled[i] = { type: 'default', url: null, isDefaultBackground: true };
             }
-            return updated;
           });
+          setSectionMedia(filled);
+          setAutoFilledImageCount(imageCount);
+        } else {
+          setAutoFilledImageCount(0);
+          // cycle-2: BE 가 default_slot_count 만큼 부족 슬롯을 알려주면 후반부를 AI 기본 배경으로 채움
+          const defaultCount: number = typeof data.default_slot_count === 'number' ? data.default_slot_count : 0;
+          if (defaultCount > 0) {
+            setSectionMedia(prev => {
+              const updated = [...prev];
+              const start = Math.max(0, 5 - defaultCount);
+              for (let i = start; i < 5; i++) {
+                updated[i] = { type: 'default', url: null, isDefaultBackground: true };
+              }
+              return updated;
+            });
+          }
         }
         setStep('select');
       } else {
@@ -274,6 +323,7 @@ export default function Home() {
     setVideoUrl(null);
     setGenerateError(null);
     setSectionMedia([null, null, null, null, null]);
+    setAutoFilledImageCount(0);
     setEditingIdx(null);
     setEditingText("");
   };
@@ -436,6 +486,15 @@ export default function Home() {
                   >
                     이미지를 선택해 주세요 — 5개를 모두 고르면 영상 생성하기가 활성화됩니다.
                   </Typography>
+                  {/* VOC-2: suggested_sections 로 자동 채워진 슬롯이 있을 때만 안내 */}
+                  {autoFilledImageCount > 0 && (
+                    <Typography
+                      variant="body2"
+                      sx={{ color: '#666', mb: 2, fontSize: 13, wordBreak: 'keep-all' }}
+                    >
+                      글 내용에 맞춰 이미지를 자동으로 넣어드렸어요. 눌러서 바꿀 수 있어요.
+                    </Typography>
+                  )}
                 </Box>
                 <Box sx={{ flex: 1, display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'flex-start', gap: 4, px: 4, py: 2, maxWidth: 1200, mx: 'auto', width: '100%' }}>
                   {/* 왼쪽: 스크립트 */}
@@ -639,6 +698,12 @@ export default function Home() {
             ) : (
               <Box sx={{ width: "100%", mb: 4 }}>
                 <Typography variant="h6" gutterBottom>생성된 스크립트</Typography>
+                {/* VOC-2: suggested_sections 로 자동 채워진 슬롯이 있을 때만 안내 */}
+                {autoFilledImageCount > 0 && (
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2, wordBreak: 'keep-all' }}>
+                    글 내용에 맞춰 이미지를 자동으로 넣어드렸어요. 눌러서 바꿀 수 있어요.
+                  </Typography>
+                )}
                 <TextField
                   label="영상 제목"
                   value={title}

--- a/auto_video_create_server/crawler/dispatcher.py
+++ b/auto_video_create_server/crawler/dispatcher.py
@@ -19,24 +19,40 @@ class UnsupportedPlatformError(Exception):
     """지원하지 않는 블로그 플랫폼."""
 
 
-def extract(url: str) -> Tuple[str, List[str], List[str], str]:
-    """블로그 URL 에서 본문/이미지/영상/플랫폼명을 추출.
+def extract_rich(url: str) -> Tuple[str, List[str], List[str], str, List[dict]]:
+    """블로그 URL 에서 본문/이미지/영상/플랫폼명 + 이미지별 컨텍스트를 추출.
 
-    Returns: (text, images, videos, platform)
+    VOC-2 (이미지 자동 매칭) 신규.
+    - naver: 캡션/주변 텍스트 완전 지원
+    - tistory/brunch: v1 은 순서 정보만 (캡션 빈 문자열)
+
+    Returns: (text, images, videos, platform, image_infos)
+             image_infos = [{"url", "caption", "context"}, ...] — images 와 같은 순서
     Raises: UnsupportedPlatformError — 지원 안 되는 도메인일 때
     """
     host = urlparse(url).netloc.lower()
 
     if "blog.naver.com" in host or host == "m.blog.naver.com":
-        text, images, videos = naver.extract_blog_content(url)
-        return text, images, videos, "naver"
+        text, images, videos, image_infos = naver.extract_blog_content_rich(url)
+        return text, images, videos, "naver", image_infos
 
     if host.endswith(".tistory.com"):
         text, images, videos = tistory.extract_blog_content(url)
-        return text, images, videos, "tistory"
-
-    if "brunch.co.kr" in host:
+    elif "brunch.co.kr" in host:
         text, images, videos = brunch.extract_blog_content(url)
-        return text, images, videos, "brunch"
+    else:
+        raise UnsupportedPlatformError(host)
 
-    raise UnsupportedPlatformError(host)
+    platform = "tistory" if host.endswith(".tistory.com") else "brunch"
+    image_infos = [{"url": u, "caption": "", "context": ""} for u in images]
+    return text, images, videos, platform, image_infos
+
+
+def extract(url: str) -> Tuple[str, List[str], List[str], str]:
+    """블로그 URL 에서 본문/이미지/영상/플랫폼명을 추출. (하위호환 시그니처)
+
+    Returns: (text, images, videos, platform)
+    Raises: UnsupportedPlatformError — 지원 안 되는 도메인일 때
+    """
+    text, images, videos, platform, _ = extract_rich(url)
+    return text, images, videos, platform

--- a/auto_video_create_server/crawler/naver.py
+++ b/auto_video_create_server/crawler/naver.py
@@ -71,11 +71,48 @@ def _extract_image_candidates(img_tag) -> List[str]:
     return candidates
 
 
-def extract_blog_content(url):
+def _extract_caption_and_context(img_tag) -> tuple:
+    """이미지 태그의 캡션(se-caption/alt)과 직후 본문 텍스트 일부를 추출한다.
+
+    VOC-2 (이미지 자동 매칭): LLM 이 '글 맥락에 맞는 이미지'를 고를 수 있도록
+    이미지별 텍스트 단서를 수집한다. 실패해도 빈 문자열로 조용히 처리 (방어적).
     """
-    네이버 블로그 글에서 본문 텍스트, 이미지 URL 리스트, 비디오 URL 리스트를 추출
-    :param url: 네이버 블로그 글 URL
-    :return: (본문 텍스트, 이미지 URL 리스트, 비디오 URL 리스트)
+    caption = (img_tag.get("alt") or "").strip()
+    try:
+        comp = img_tag.find_parent(class_=lambda c: c and "se-component" in c)
+        if comp is not None:
+            cap_el = comp.find(class_=lambda c: c and "se-caption" in c)
+            if cap_el is not None:
+                cap_text = cap_el.get_text(" ", strip=True)
+                if cap_text:
+                    caption = cap_text
+    except Exception:
+        pass
+
+    context = ""
+    try:
+        parts = []
+        total = 0
+        for s in img_tag.find_all_next(string=True):
+            t = s.strip()
+            if not t:
+                continue
+            parts.append(t)
+            total += len(t)
+            if total >= 80:
+                break
+        context = " ".join(parts)[:80]
+    except Exception:
+        context = ""
+    return caption[:60], context
+
+
+def extract_blog_content_rich(url):
+    """네이버 블로그 글에서 본문/이미지/비디오 + 이미지별 컨텍스트를 추출.
+
+    VOC-2 (이미지 자동 매칭) 신규.
+    :return: (text, images, videos, image_infos)
+             image_infos = [{"url", "caption", "context"}, ...] — images 와 같은 순서/길이
     """
     resp = requests.get(url)
     resp.raise_for_status()
@@ -104,19 +141,25 @@ def extract_blog_content(url):
     # https://postfiles.pstatic.net/MjAyNTA1MDlfMTYg/MDAxNzQ2NzkyNjgyNTc2.ier0FJ-ccb5aPRgLALg5MdbadK33W8m6cgh0jeoMIJQg.wZof1W8HIwiECHl_uHAURh0PmzUBzq3rrP7vOHLRdwQg.JPEG/IMG_2224.JPG?type=w966
     # https://postfiles.pstatic.net/MjAyNTA1MDlfMTYg/MDAxNzQ2NzkyNjgyNTc2.ier0FJ-ccb5aPRgLALg5MdbadK33W8m6cgh0jeoMIJQg.wZof1W8HIwiECHl_uHAURh0PmzUBzq3rrP7vOHLRdwQg.JPEG/IMG_2224.JPG?type=w80_blur
 
-    # 이미지 링크 추출
+    # 이미지 링크 추출 (+ VOC-2: 이미지별 캡션/주변 텍스트)
     images = []
+    image_infos = []
     seen_images = set()
     img_count = 0
     for img in main_area.find_all('img'):
+        caption = None  # 태그당 1회만 계산 (lazy)
+        context = None
         for candidate in _extract_image_candidates(img):
             full_url = _normalize_image_url(url, candidate)
             if not _is_valid_naver_image_url(full_url):
                 continue
             if full_url in seen_images:
                 continue
+            if caption is None:
+                caption, context = _extract_caption_and_context(img)
             seen_images.add(full_url)
             images.append(full_url)
+            image_infos.append({"url": full_url, "caption": caption, "context": context})
             img_count += 1
             print(f"[이미지 {img_count}] {full_url}")
 
@@ -137,6 +180,16 @@ def extract_blog_content(url):
                 video_count += 1
                 print(f"[비디오 {video_count}] {urljoin(url, src)}")
 
+    return text, images, videos, image_infos
+
+
+def extract_blog_content(url):
+    """
+    네이버 블로그 글에서 본문 텍스트, 이미지 URL 리스트, 비디오 URL 리스트를 추출
+    (하위호환 시그니처 유지 — rich 버전 extract_blog_content_rich 위임)
+    :return: (본문 텍스트, 이미지 URL 리스트, 비디오 URL 리스트)
+    """
+    text, images, videos, _ = extract_blog_content_rich(url)
     return text, images, videos
 
 # 콘솔에서만 사용할 선택 함수 (API에서는 사용하지 않음)

--- a/auto_video_create_server/services/blog_shorts.py
+++ b/auto_video_create_server/services/blog_shorts.py
@@ -5,22 +5,70 @@ cycle-2 갱신:
 - services.classifier 로 맛집 vs 일반 자동 분류
 - summarize 에 category 전달 → 카테고리별 프롬프트 분기
 - default_slot_count 계산 (이미지 + 영상 < 5 일 때)
+
+VOC-2 갱신 (이미지 자동 매칭):
+- dispatcher.extract_rich 로 이미지별 캡션/주변 텍스트 수집 (naver 완전 지원)
+- summarize 피기백으로 스크립트별 image_index(1-based) 수신
+- suggested_sections 조립: LLM 매칭 → 위치 기반 폴백 → 부족分 default
+  (자동 배정은 FE 의 default 제안일 뿐 — 유저가 수동으로 바꿀 수 있다)
 """
-from crawler.dispatcher import extract as dispatcher_extract
+from crawler.dispatcher import extract_rich as dispatcher_extract_rich
 from crawler.dispatcher import UnsupportedPlatformError  # noqa: F401  (re-export)
 from crawler.naver import extract_blog_content  # noqa: F401  (backward-compat re-export)
 from .summarize import summarize_for_shorts_sets
 from .classifier import classify_blog
 
 
+def _normalize_image_indices(scripts, image_count):
+    """scripts 원소에서 image_index(1-based)를 꺼내 0-based 유효 인덱스 리스트로.
+
+    - scripts 원소 dict 에서 image_index 를 제거한다 (FE 응답 스키마 오염 방지).
+    - 무효(범위 밖/비정수/bool)·중복(첫 등장 우선) 인덱스는 None 처리.
+    """
+    used = set()
+    indices = []
+    for s in scripts:
+        idx = None
+        if isinstance(s, dict):
+            raw = s.pop("image_index", None)
+            if isinstance(raw, int) and not isinstance(raw, bool):
+                zero = raw - 1
+                if 0 <= zero < image_count and zero not in used:
+                    idx = zero
+                    used.add(zero)
+        indices.append(idx)
+    return indices
+
+
+def _build_suggested_sections(indices, images):
+    """0-based 인덱스 리스트 → suggested_sections 조립.
+
+    - None 슬롯은 위치 기반 폴백: 아직 안 쓰인 이미지를 본문 등장 순서대로 배정.
+    - 이미지가 부족하면 {"type": "default", "url": None} (기존 AI 배경 슬롯 규칙).
+    """
+    used = {i for i in indices if i is not None}
+    remaining = [i for i in range(len(images)) if i not in used]
+    sections = []
+    for idx in indices:
+        if idx is None and remaining:
+            idx = remaining.pop(0)
+        if idx is not None:
+            sections.append({"type": "image", "url": images[idx]})
+        else:
+            sections.append({"type": "default", "url": None})
+    return sections
+
+
 def get_blog_media_and_scripts(blog_url: str) -> dict:
-    """블로그 URL 1개 → 추출 + 분류 + 스크립트 생성 + 슬롯 부족 카운트."""
-    text, images, videos, platform = dispatcher_extract(blog_url)
+    """블로그 URL 1개 → 추출 + 분류 + 스크립트 생성 + 슬롯 부족 카운트 + 자동 배정 제안."""
+    text, images, videos, platform, image_infos = dispatcher_extract_rich(blog_url)
     category = classify_blog(text)
-    title, scripts = summarize_for_shorts_sets(text, category=category)
+    title, scripts = summarize_for_shorts_sets(
+        text, category=category, image_infos=image_infos or None
+    )
     # 5개 슬롯 중 이미지+영상으로 채워지지 않는 슬롯 수
     default_slot_count = max(0, 5 - (len(images) + len(videos)))
-    return {
+    result = {
         "text": text,
         "images": images,
         "videos": videos,
@@ -30,3 +78,10 @@ def get_blog_media_and_scripts(blog_url: str) -> dict:
         "platform": platform,
         "default_slot_count": default_slot_count,
     }
+    # VOC-2: 자동 배정 제안. 실패해도 전체 응답은 정상 (필드 생략 → FE 가 기존 폴백).
+    try:
+        indices = _normalize_image_indices(scripts, len(images))
+        result["suggested_sections"] = _build_suggested_sections(indices, images)
+    except Exception as e:
+        print(f"[blog_shorts] suggested_sections 조립 실패 — 필드 생략: {e}")
+    return result

--- a/auto_video_create_server/services/summarize.py
+++ b/auto_video_create_server/services/summarize.py
@@ -27,6 +27,54 @@ SHORTS_OUTPUT_SCHEMA = {
     "additionalProperties": False,
 }
 
+# VOC-2 (이미지 자동 매칭): 이미지 목록이 있을 때 쓰는 확장 스키마 —
+# 스크립트별로 어울리는 이미지 번호(1-based)를 함께 받는다.
+SHORTS_OUTPUT_SCHEMA_WITH_IMAGES = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "scripts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "script": {"type": "string"},
+                    "image_index": {"type": ["integer", "null"]},
+                },
+                "required": ["script", "image_index"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["title", "scripts"],
+    "additionalProperties": False,
+}
+
+# VOC-2: 기존 카테고리 프롬프트 뒤에 붙이는 이미지 매칭 부록.
+# 기존 스크립트 생성 호출에 피기백 — 추가 API 호출 없음 (30초 타임아웃 안전).
+IMAGE_MATCHING_ADDENDUM = """
+
+- 이미지 자동 매칭 (추가 작업):
+아래는 블로그 본문에서 추출한 이미지 목록이야. 번호는 1부터 시작해.
+각 스크립트 내용에 가장 잘 어울리는 이미지 번호를 각 스크립트의 "image_index" 로 함께 반환해줘.
+규칙:
+1) 같은 번호를 두 번 이상 쓰지 마 (스크립트마다 서로 다른 이미지).
+2) 어울리는 이미지가 정말 없으면 null 을 넣어.
+3) scripts 의 각 원소는 {{"script": "...", "image_index": 번호 또는 null}} 형태여야 해.
+
+이미지 목록:
+{image_list}
+"""
+
+
+def _format_image_list_for_prompt(image_infos, limit=20):
+    """image_infos → 프롬프트용 번호 목록 텍스트 (1-based, 최대 limit개)."""
+    lines = []
+    for i, info in enumerate(image_infos[:limit], start=1):
+        desc = (info.get("caption") or "").strip() or (info.get("context") or "").strip() or "(설명 없음)"
+        lines.append(f"[{i}] {desc[:80]}")
+    return "\n".join(lines)
+
 def extract_json_from_codeblock(content):
     match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", content)
     if match:
@@ -121,7 +169,7 @@ GENERAL_PROMPT = """
 """
 
 
-def _generate_with_claude(prompt):
+def _generate_with_claude(prompt, schema=None):
     """Claude Sonnet 으로 title+scripts JSON 텍스트 생성. refusal 시 None."""
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
     # Sonnet 5 는 adaptive thinking 이 기본이라 max_tokens 에 사고 토큰 여유가 필요.
@@ -131,7 +179,7 @@ def _generate_with_claude(prompt):
         max_tokens=4000,
         output_config={
             "effort": "low",
-            "format": {"type": "json_schema", "schema": SHORTS_OUTPUT_SCHEMA},
+            "format": {"type": "json_schema", "schema": schema or SHORTS_OUTPUT_SCHEMA},
         },
         system="당신은 유능한 영상 스크립트 작가입니다.",
         messages=[{"role": "user", "content": prompt}],
@@ -159,20 +207,36 @@ def _generate_with_openai(prompt):
     return response.choices[0].message.content.strip()
 
 
-def summarize_for_shorts_sets(text, category: str = "restaurant"):
+def summarize_for_shorts_sets(text, category: str = "restaurant", image_infos=None):
     """카테고리에 따라 다른 프롬프트로 쇼츠용 title+scripts(5개) 생성.
 
     ANTHROPIC_API_KEY 가 있으면 Claude Sonnet, 없으면 기존 OpenAI 로 동작.
 
+    VOC-2: image_infos 가 있으면 이미지 매칭 부록을 피기백 —
+    scripts 각 원소에 image_index(1-based 또는 null) 가 포함될 수 있다.
+    호출부(blog_shorts)가 꺼내 쓰고 FE 응답에서는 제거한다.
+
     Args:
         text: 블로그 본문
         category: 'restaurant' (맛집, 기존) 또는 'general' (일반 블로그)
+        image_infos: [{"url","caption","context"}, ...] 또는 None
     """
     template = RESTAURANT_PROMPT if category == "restaurant" else GENERAL_PROMPT
     prompt = template.format(text=text)
+    schema = SHORTS_OUTPUT_SCHEMA
+    if image_infos:
+        try:
+            prompt += IMAGE_MATCHING_ADDENDUM.format(
+                image_list=_format_image_list_for_prompt(image_infos)
+            )
+            schema = SHORTS_OUTPUT_SCHEMA_WITH_IMAGES
+        except Exception as e:
+            # 이미지 부록 구성 실패 시 매칭 없이 기존 동작 (방어적)
+            print(f"[summarize] 이미지 매칭 부록 구성 실패 — 매칭 없이 진행: {e}")
+            schema = SHORTS_OUTPUT_SCHEMA
     try:
         if os.environ.get("ANTHROPIC_API_KEY"):
-            content = _generate_with_claude(prompt)
+            content = _generate_with_claude(prompt, schema=schema)
         else:
             print("[summarize] ANTHROPIC_API_KEY 미설정 — OpenAI fallback 사용")
             content = _generate_with_openai(prompt)

--- a/auto_video_create_server/tests/test_auto_image_matching.py
+++ b/auto_video_create_server/tests/test_auto_image_matching.py
@@ -1,0 +1,117 @@
+"""VOC-2 이미지 자동 매칭 — 후처리 로직 단위 테스트.
+
+대상 (순수 함수만 — 외부 API/크롤링 없음):
+- services.blog_shorts._normalize_image_indices : 1-based → 0-based, 무효/중복 제거, dict 에서 키 제거
+- services.blog_shorts._build_suggested_sections : LLM 매칭 + 위치 폴백 + default 채움
+- services.summarize._format_image_list_for_prompt : 프롬프트 목록 포맷
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services.blog_shorts import (  # noqa: E402
+    _normalize_image_indices,
+    _build_suggested_sections,
+)
+from services.summarize import _format_image_list_for_prompt  # noqa: E402
+
+IMAGES = ["u0", "u1", "u2", "u3", "u4"]
+
+
+class TestNormalizeImageIndices(unittest.TestCase):
+    def test_valid_one_based_converted(self):
+        scripts = [{"script": "a", "image_index": 1}, {"script": "b", "image_index": 3}]
+        self.assertEqual(_normalize_image_indices(scripts, 5), [0, 2])
+
+    def test_image_index_removed_from_scripts(self):
+        scripts = [{"script": "a", "image_index": 1}]
+        _normalize_image_indices(scripts, 5)
+        self.assertNotIn("image_index", scripts[0])
+
+    def test_null_and_missing_become_none(self):
+        scripts = [{"script": "a", "image_index": None}, {"script": "b"}]
+        self.assertEqual(_normalize_image_indices(scripts, 5), [None, None])
+
+    def test_out_of_range_invalid(self):
+        scripts = [
+            {"script": "a", "image_index": 0},   # 1-based 이므로 0 은 무효
+            {"script": "b", "image_index": 6},   # 범위 밖
+            {"script": "c", "image_index": -1},
+        ]
+        self.assertEqual(_normalize_image_indices(scripts, 5), [None, None, None])
+
+    def test_duplicate_first_wins(self):
+        scripts = [
+            {"script": "a", "image_index": 2},
+            {"script": "b", "image_index": 2},  # 중복 → None
+        ]
+        self.assertEqual(_normalize_image_indices(scripts, 5), [1, None])
+
+    def test_bool_and_str_invalid(self):
+        scripts = [
+            {"script": "a", "image_index": True},   # bool 은 int 서브클래스지만 거부
+            {"script": "b", "image_index": "2"},
+        ]
+        self.assertEqual(_normalize_image_indices(scripts, 5), [None, None])
+
+
+class TestBuildSuggestedSections(unittest.TestCase):
+    def test_all_matched(self):
+        sections = _build_suggested_sections([0, 2], IMAGES)
+        self.assertEqual(sections, [
+            {"type": "image", "url": "u0"},
+            {"type": "image", "url": "u2"},
+        ])
+
+    def test_position_fallback_skips_used(self):
+        # 두 번째 슬롯 None → 아직 안 쓰인 이미지 중 가장 앞(u1)
+        sections = _build_suggested_sections([0, None, 2], IMAGES)
+        self.assertEqual(sections[1], {"type": "image", "url": "u1"})
+
+    def test_all_none_falls_back_in_order(self):
+        # LLM 이 전부 null 이어도 (OpenAI 폴백 미지원 응답 등) 순서대로 자동 채움
+        sections = _build_suggested_sections([None, None, None], IMAGES)
+        self.assertEqual([s["url"] for s in sections], ["u0", "u1", "u2"])
+
+    def test_default_when_images_exhausted(self):
+        sections = _build_suggested_sections([None, None, None], ["u0"])
+        self.assertEqual(sections[0], {"type": "image", "url": "u0"})
+        self.assertEqual(sections[1], {"type": "default", "url": None})
+        self.assertEqual(sections[2], {"type": "default", "url": None})
+
+    def test_no_images_all_default(self):
+        sections = _build_suggested_sections([None, None], [])
+        self.assertEqual(sections, [
+            {"type": "default", "url": None},
+            {"type": "default", "url": None},
+        ])
+
+    def test_length_matches_scripts(self):
+        self.assertEqual(len(_build_suggested_sections([None] * 5, IMAGES)), 5)
+
+
+class TestFormatImageList(unittest.TestCase):
+    def test_caption_preferred_over_context(self):
+        infos = [{"url": "u", "caption": "본죽 사진", "context": "주변텍스트"}]
+        self.assertIn("[1] 본죽 사진", _format_image_list_for_prompt(infos))
+
+    def test_context_fallback_and_empty(self):
+        infos = [
+            {"url": "u", "caption": "", "context": "주변 텍스트"},
+            {"url": "u2", "caption": "", "context": ""},
+        ]
+        out = _format_image_list_for_prompt(infos)
+        self.assertIn("[1] 주변 텍스트", out)
+        self.assertIn("[2] (설명 없음)", out)
+
+    def test_limit_20(self):
+        infos = [{"url": f"u{i}", "caption": f"c{i}", "context": ""} for i in range(30)]
+        out = _format_image_list_for_prompt(infos)
+        self.assertIn("[20]", out)
+        self.assertNotIn("[21]", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auto_video_create_server/tests/test_style_templates.py
+++ b/auto_video_create_server/tests/test_style_templates.py
@@ -250,10 +250,20 @@ class TestUpdateSubtitleTemplate(StyleTemplatesTestCase):
 class TestDeleteSubtitleTemplate(StyleTemplatesTestCase):
 
     def test_delete_success(self):
-        self.svc.delete_subtitle_template("templated_user", "tpl-1")
+        # 2개 이상인 유저(five_templates_user)에서 삭제 — 마지막 1개 아님
+        templates = self.svc.get_subtitle_templates("five_templates_user")
+        target_id = templates[0]["id"]
+        self.svc.delete_subtitle_template("five_templates_user", target_id)
         saved_users = self._put_object_body()
-        saved_user = self._find_user(saved_users, "templated_user")
-        self.assertEqual(saved_user["subtitle_templates"], [])
+        saved_user = self._find_user(saved_users, "five_templates_user")
+        self.assertEqual(len(saved_user["subtitle_templates"]), 4)
+        self.assertNotIn(target_id, [t["id"] for t in saved_user["subtitle_templates"]])
+
+    def test_delete_last_template_blocked(self):
+        """마지막 남은 1개 템플릿 삭제는 서버가 차단 (최소 1개 유지 — PO 확정 2026-08-02)."""
+        with self.assertRaises(self.svc.LastTemplateError):
+            self.svc.delete_subtitle_template("templated_user", "tpl-1")
+        self.mock_s3.put_object.assert_not_called()
 
     def test_delete_missing_template_raises_not_found(self):
         with self.assertRaises(self.svc.TemplateNotFoundError):
@@ -265,11 +275,14 @@ class TestDeleteSubtitleTemplate(StyleTemplatesTestCase):
             self.svc.delete_subtitle_template("nonexistent_user", "tpl-1")
 
     def test_delete_from_legacy_migrated_list(self):
-        """legacy 유저도 마이그레이션된 항목을 삭제할 수 있어야 함(lazy 영속화 확인 포함).
+        """legacy 유저의 마이그레이션 id 가 결정적(uuid5)인지 + DELETE 가 그 id 를 인식하는지.
 
         GET 과 DELETE 는 각각 별도로 load_json_from_s3 를 호출(=별도로 마이그레이션)
         하므로, id 가 결정적(uuid5)이지 않으면 GET 에서 받은 id 로 DELETE 가 404 나는
         회귀가 발생한다 — 이 테스트는 그 회귀를 방지한다.
+
+        (갱신) 마지막 1개 삭제는 이제 LastTemplateError 로 차단되므로, "id 를 인식했다"는
+        것은 TemplateNotFoundError(404)가 아니라 LastTemplateError 가 나오는 것으로 검증.
         """
         templates = self.svc.get_subtitle_templates("legacy_user")
         migrated_id = templates[0]["id"]
@@ -278,10 +291,9 @@ class TestDeleteSubtitleTemplate(StyleTemplatesTestCase):
         templates_again = self.svc.get_subtitle_templates("legacy_user")
         self.assertEqual(templates_again[0]["id"], migrated_id)
 
-        self.svc.delete_subtitle_template("legacy_user", migrated_id)
-        saved_users = self._put_object_body()
-        saved_user = self._find_user(saved_users, "legacy_user")
-        self.assertEqual(saved_user["subtitle_templates"], [])
+        # 결정적 id 가 인식됨 → NotFound(회귀)가 아니라 마지막 1개 차단 에러
+        with self.assertRaises(self.svc.LastTemplateError):
+            self.svc.delete_subtitle_template("legacy_user", migrated_id)
 
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## VOC-2 — 링크만 넣으면 이미지 자동 배정

유저 VOC: "링크만 넣으면 글의 맥락에 맞는 이미지를 자동으로." PO 확정: **자동은 default 제안일 뿐, 강제 아님** — 미리 채워주고 수동 교체 가능.

### 방식
- **LLM 피기백**: 기존 스크립트 생성 호출에 이미지 목록(번호+캡션+주변텍스트)을 얹어 스크립트별 `image_index` 수신 — **추가 API 호출 0, 30초 타임아웃 안전**. Claude(json_schema)·OpenAI(프롬프트) 두 경로
- **크롤러**: naver 캡션(se-caption/alt)+주변텍스트 추출, tistory/brunch 순서 기반. 시그니처 하위호환
- **폴백**: 무효/중복/null → 본문 등장 순서대로 배정, 이미지 부족分은 기존 default(AI 배경)
- **FE**: `suggested_sections`로 슬롯 미리 채움 + 안내 1줄, 방어적 파싱(형식 안 맞으면 기존 폴백), 수동 선택 로직 무변경

### 부수
- PR #53 핫픽스 때 누락된 삭제 테스트 정합 (LastTemplateError 반영) — BE CI가 compileall만 해서 조용히 지나갔던 것

### 테스트
- 신규 15개(인덱스 정규화/폴백/프롬프트 포맷) + 기존 45개 = 60개 통과 (로컬)

🤖 Generated with [Claude Code](https://claude.com/claude-code)