### PR TITLE
fix: 3번 장면 자막 스타일 누락 (Subtitles-MDV)

### DIFF
--- a/auto_video_create_server/services/scene_counts.py
+++ b/auto_video_create_server/services/scene_counts.py
@@ -24,15 +24,17 @@ DEFAULT_SCENE_COUNT = 5
 # NOTE (2026-08-04, PO 템플릿 제공): 4/6/7/8 템플릿은 prod/test 구분 없이 동일 ID 를 사용한다
 # (PO 가 장면 수당 템플릿 1개씩 제공). 5장면만 기존처럼 prod/test 가 분리돼 있다.
 #
-# NOTE (자막 suffix): 신규 템플릿 4종은 모두 **3번 슬롯에 자막 element 가 없다**
-# (6K5=1번, JTM=2번, 5Z2=4번, D6M=5번, 3KT=6번, 6PM=7번, 3P6=8번).
-# 따라서 suffix 개수는 장면 수보다 1 적다. 자막 스타일 주입은 존재하는 element 에만
-# 적용되므로 동작에는 문제가 없으나, 3번 장면 자막이 의도된 것인지는 PO 확인 대상.
+# NOTE (자막 suffix, 2026-08-04 정정): 3번 슬롯 자막은 `Subtitles-MDV` 로 **존재한다**.
+# 최초 등록 시 참고한 Creatomate "API 사용" 예시(curl)에 MDV 가 빠져 있어 없는 줄 알았는데,
+# 실제 템플릿 JSON 을 보니 composition_3 의 Subtitles-MDV 만 `"dynamic": true` 가 누락돼
+# 예시에서 제외됐던 것이다. 그 결과 3번 장면에만 자막 스타일(폰트/색)이 주입되지 않아
+# 템플릿 기본값(Montserrat/흰색)으로 렌더되는 버그가 있었다.
+# → 전 장면 수에 MDV 를 포함한다. 슬롯 순서: 1=6K5 2=JTM 3=MDV 4=5Z2 5=D6M 6=3KT 7=6PM 8=3P6
 SCENE_COUNT_CONFIG: dict = {
     4: {
         "template_id_prod": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
         "template_id_test": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
-        "subtitle_suffixes": ["6K5", "JTM", "5Z2"],  # 3번 슬롯 자막 element 없음
+        "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2"],
     },
     5: {
         # 현행 운영 템플릿 (기존 동작 100% 유지)
@@ -43,17 +45,17 @@ SCENE_COUNT_CONFIG: dict = {
     6: {
         "template_id_prod": "5e530b01-2f3d-428e-b6d6-70a001703550",
         "template_id_test": "5e530b01-2f3d-428e-b6d6-70a001703550",
-        "subtitle_suffixes": ["6K5", "JTM", "5Z2", "D6M", "3KT"],  # 3번 슬롯 없음
+        "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT"],
     },
     7: {
         "template_id_prod": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
         "template_id_test": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
-        "subtitle_suffixes": ["6K5", "JTM", "5Z2", "D6M", "3KT", "6PM"],  # 3번 슬롯 없음
+        "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM"],
     },
     8: {
         "template_id_prod": "37229115-682d-41d5-b1f1-20953367b416",
         "template_id_test": "37229115-682d-41d5-b1f1-20953367b416",
-        "subtitle_suffixes": ["6K5", "JTM", "5Z2", "D6M", "3KT", "6PM", "3P6"],  # 3번 슬롯 없음
+        "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM", "3P6"],
     },
 }
 

--- a/auto_video_create_server/tests/test_scene_counts.py
+++ b/auto_video_create_server/tests/test_scene_counts.py
@@ -76,15 +76,22 @@ class TestSubtitleSuffixes(unittest.TestCase):
         for n in [4, 5, 6, 7, 8]:
             self.assertTrue(sc.get_subtitle_suffixes(n), f"{n}장면 suffix 미등록")
 
-    def test_suffix_count_never_exceeds_scene_count(self):
-        """suffix 는 장면 수를 넘을 수 없다 (넘으면 존재하지 않는 element 주입).
+    def test_suffix_count_equals_scene_count(self):
+        """모든 장면에 자막 스타일이 주입되도록 suffix 개수 = 장면 수 여야 한다.
 
-        신규 템플릿 4종(4/6/7/8)은 3번 슬롯에 자막 element 가 없어 N-1 개다 —
-        의도된 상태인지는 PO 확인 대상이나, 초과만 아니면 주입은 안전하다.
+        회귀 방지: 3번 슬롯(MDV)이 빠져 있어 3번 장면만 템플릿 기본 스타일
+        (Montserrat/흰색)로 렌더되던 버그(2026-08-04).
         """
         for n, config in sc.SCENE_COUNT_CONFIG.items():
             suffixes = config.get("subtitle_suffixes") or []
-            self.assertLessEqual(len(suffixes), n, f"{n}장면 suffix 가 장면 수 초과")
+            self.assertEqual(len(suffixes), n, f"{n}장면 suffix 개수 불일치: {suffixes}")
+
+    def test_third_slot_subtitle_present(self):
+        """3번 슬롯 자막(MDV)이 모든 장면 수에 포함돼야 한다 (위 버그 직접 고정)."""
+        for n in sc.ALLOWED_SCENE_COUNTS:
+            suffixes = sc.get_subtitle_suffixes(n) or []
+            self.assertIn("MDV", suffixes, f"{n}장면에 3번 슬롯 자막(MDV) 누락")
+            self.assertEqual(suffixes[2], "MDV", f"{n}장면 MDV 위치가 3번이 아님")
 
     def test_suffixes_unique_within_template(self):
         for n, config in sc.SCENE_COUNT_CONFIG.items():


### PR DESCRIPTION
## 증상
영상 중간(3번 장면)에만 자막이 사용자가 고른 스타일이 아니라 템플릿 기본값(Montserrat/흰색)으로 렌더됨.

## 원인
3번 슬롯 자막 element `Subtitles-MDV` 는 템플릿에 **존재하지만**, `composition_3` 의 그 element 만 `"dynamic": true` 가 빠져 있어 Creatomate 의 "API 사용" 예시(curl)에 노출되지 않았다. 그 예시를 근거로 suffix 목록을 등록하면서 MDV 가 빠졌고, 결과적으로 3번 장면에만 스타일 주입이 안 됐다.

실제 렌더 로그에서도 7개(`3KT,3P6,5Z2,6K5,6PM,D6M,JTM`)에만 스타일이 주입되고 MDV 는 없음.

## 수정
- 4/6/7/8 장면 suffix 에 `MDV` 를 3번 위치로 추가 (5장면은 원래 있었음)
- 슬롯 순서 고정: 1=6K5 2=JTM 3=MDV 4=5Z2 5=D6M 6=3KT 7=6PM 8=3P6
- 회귀 테스트: suffix 개수 == 장면 수 / MDV 가 항상 3번 위치

## 관련 (코드 아님 — 템플릿에서 수정 완료)
`composition_8` 에만 시작 시각이 `time: 40.383` 으로 하드코딩돼 장면 7 종료(12.77s) 후 **27.6초 빈 화면**이 나오던 문제 → PO 가 Creatomate 템플릿에서 수정.

테스트 94개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)