### PR TITLE
feat: 무제한 플랜 (기간제 크레딧 면제)

### DIFF
--- a/auto_video_create_server/scripts/manage_credits.py
+++ b/auto_video_create_server/scripts/manage_credits.py
@@ -189,6 +189,86 @@ def set_initial_credits(user_id, amount, reason="initial_setup"):
         print(f"[!] 초기 크레딧 설정 실패: {e}")
         return False
 
+def _unlimited_status(user):
+    """무제한 플랜 상태 문자열. (BE is_unlimited_active 와 동일 규칙)"""
+    start, end = user.get("unlimited_start"), user.get("unlimited_end")
+    if not start or not end:
+        return "-"
+    try:
+        today = datetime.utcnow().date()
+        s = datetime.strptime(start, "%Y-%m-%d").date()
+        e = datetime.strptime(end, "%Y-%m-%d").date()
+    except ValueError:
+        return "형식오류"
+    if today < s:
+        return f"예정({start}~{end})"
+    if today > e:
+        return f"만료({end})"
+    return f"무제한중(~{end})"
+
+
+def set_unlimited_plan(user_id, start, end):
+    """무제한 플랜 기간 설정. 기간 중에는 크레딧 차감 없이 무제한 생성."""
+    try:
+        s = datetime.strptime(start, "%Y-%m-%d").date()
+        e = datetime.strptime(end, "%Y-%m-%d").date()
+    except ValueError:
+        print("[!] 날짜는 YYYY-MM-DD 형식으로 입력해주세요.")
+        return
+    if e < s:
+        print("[!] 종료일이 시작일보다 빠릅니다.")
+        return
+
+    users = download_users()
+    for user in users:
+        if user["id"] == user_id:
+            user["unlimited_start"] = start
+            user["unlimited_end"] = end
+            upload_users(users)
+            print(f"[*] {user_id} 무제한 플랜 설정: {start} ~ {end}")
+            # 구독 기간과는 별도 관리 — 구독이 만료돼 있으면 로그인 자체가 막히므로 경고만 한다.
+            sub_end = user.get("subscription_end")
+            try:
+                if sub_end and datetime.strptime(sub_end, "%Y-%m-%d").date() < e:
+                    print(f"[!] 주의: 구독 종료일({sub_end})이 무제한 종료일({end})보다 빠릅니다.")
+                    print("    구독이 만료되면 로그인 자체가 막혀 무제한도 쓸 수 없습니다.")
+                    print("    edit_users_json.py 의 '4. 구독일 변경' 으로 구독 기간을 함께 늘려주세요.")
+            except ValueError:
+                pass
+            save_credit_record({
+                "user_id": user_id,
+                "timestamp": datetime.utcnow().isoformat(),
+                "change_type": "unlimited_set",
+                "amount": 0,
+                "reason": f"unlimited_plan {start}~{end}",
+            })
+            return
+    print(f"[!] 사용자 {user_id}를 찾을 수 없습니다.")
+
+
+def clear_unlimited_plan(user_id):
+    """무제한 플랜 해제 (일반 크레딧 정책으로 복귀)."""
+    users = download_users()
+    for user in users:
+        if user["id"] == user_id:
+            if not user.get("unlimited_start") and not user.get("unlimited_end"):
+                print(f"[!] {user_id}는 무제한 플랜이 설정돼 있지 않습니다.")
+                return
+            user.pop("unlimited_start", None)
+            user.pop("unlimited_end", None)
+            upload_users(users)
+            print(f"[*] {user_id} 무제한 플랜 해제 완료. 이후 크레딧 차감 정상 적용.")
+            save_credit_record({
+                "user_id": user_id,
+                "timestamp": datetime.utcnow().isoformat(),
+                "change_type": "unlimited_clear",
+                "amount": 0,
+                "reason": "unlimited_plan cleared",
+            })
+            return
+    print(f"[!] 사용자 {user_id}를 찾을 수 없습니다.")
+
+
 def list_users_with_credits():
     """크레딧 정보와 함께 사용자 목록 출력"""
     users = download_users()
@@ -196,7 +276,8 @@ def list_users_with_credits():
     for i, user in enumerate(users):
         credits = user.get("credits", 0)
         blog_url = user.get('blog_url', '없음')
-        print(f"{i+1}. id: {user['id']}, 크레딧: {credits}, 구독: {user['subscription_start']} ~ {user['subscription_end']}, 블로그: {blog_url}")
+        unlimited = _unlimited_status(user)
+        print(f"{i+1}. id: {user['id']}, 크레딧: {credits}, 무제한: {unlimited}, 구독: {user['subscription_start']} ~ {user['subscription_end']}, 블로그: {blog_url}")
     print()
 
 def show_credit_history(user_id):
@@ -208,7 +289,10 @@ def show_credit_history(user_id):
     
     print(f"\n=== {user_id} 크레딧 변경 이력 (최근 20건) ===")
     for record in history:
-        change_type_kr = {"add": "추가", "deduct": "차감", "initial": "초기설정"}.get(record["change_type"], record["change_type"])
+        change_type_kr = {
+            "add": "추가", "deduct": "차감", "initial": "초기설정",
+            "unlimited_use": "무제한사용", "unlimited_set": "무제한설정", "unlimited_clear": "무제한해제",
+        }.get(record["change_type"], record["change_type"])
         print(f"{record['timestamp']} | {change_type_kr} | {record['amount']:+d} | {record['reason']}")
     print()
 
@@ -220,7 +304,9 @@ def main():
         print("3. 크레딧 차감")
         print("4. 초기 크레딧 설정")
         print("5. 크레딧 이력 보기")
-        print("6. 종료")
+        print("6. 무제한 플랜 설정 (기간 중 차감 없이 무제한 생성)")
+        print("7. 무제한 플랜 해제")
+        print("8. 종료")
         
         sel = input("선택: ").strip()
         
@@ -257,8 +343,18 @@ def main():
         elif sel == "5":
             user_id = input("사용자 ID: ").strip()
             show_credit_history(user_id)
-            
+
         elif sel == "6":
+            user_id = input("사용자 ID: ").strip()
+            start = input("무제한 시작일(YYYY-MM-DD): ").strip()
+            end = input("무제한 종료일(YYYY-MM-DD): ").strip()
+            set_unlimited_plan(user_id, start, end)
+
+        elif sel == "7":
+            user_id = input("사용자 ID: ").strip()
+            clear_unlimited_plan(user_id)
+
+        elif sel == "8":
             print("종료합니다.")
             break
             

--- a/auto_video_create_server/services/account_service.py
+++ b/auto_video_create_server/services/account_service.py
@@ -1,8 +1,52 @@
+# PEP 604 (`dict | str | None`) 어노테이션이 Python 3.9 에서도 import 가능하도록
+# 어노테이션을 지연 평가한다. Lambda 는 3.11 이라 동작에 영향 없고, 로컬(3.9)에서
+# 단위 테스트를 돌릴 수 있게 된다.
+from __future__ import annotations
+
 from utils.s3_utils import load_json_from_s3
 from datetime import datetime
 import boto3
 import json
 import os
+
+def _parse_date(value):
+    """YYYY-MM-DD 문자열 → date. 형식이 아니면 None (기존 구독 검증과 동일 포맷)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def is_unlimited_active(user: dict) -> bool:
+    """무제한 플랜 기간 중인지 판정 (user dict 기준, S3 재조회 없음).
+
+    무제한 플랜: `unlimited_start` ~ `unlimited_end` (YYYY-MM-DD, 양끝 포함) 사이에는
+    크레딧 잔액과 무관하게 영상을 생성할 수 있고 차감도 하지 않는다.
+
+    - 구독 기간과는 **별개로 관리**한다 (PO 확정 2026-08-05). 단 구독이 만료되면
+      로그인 자체가 막히므로, 무제한을 부여할 때 구독 기간도 함께 열어둬야 한다.
+    - 두 날짜 중 하나라도 없거나 형식이 잘못되면 무제한 아님(False)으로 안전 처리.
+    """
+    if not isinstance(user, dict):
+        return False
+    start = _parse_date(user.get("unlimited_start"))
+    end = _parse_date(user.get("unlimited_end"))
+    if start is None or end is None:
+        return False
+    today = datetime.utcnow().date()
+    return start <= today <= end
+
+
+def is_unlimited_active_by_id(user_id: str) -> bool:
+    """user_id 로 무제한 여부 조회 (S3 조회 포함)."""
+    users = load_json_from_s3("blog-to-short-form-users", "users.json")
+    for user in users:
+        if user["id"] == user_id:
+            return is_unlimited_active(user)
+    return False
+
 
 def authenticate_user(user_id: str, pw: str) -> dict | str | None:
     users = load_json_from_s3("blog-to-short-form-users", "users.json")
@@ -64,8 +108,12 @@ def check_user_credits(user_id: str, required_credits: int = 1000) -> bool:
     """사용자의 크레딧이 충분한지 체크.
 
     cycle-2 (ADR-6): ENV=test 환경에서는 항상 True (deduct_credits 와 일관).
+    무제한 플랜 기간 중이면 잔액과 무관하게 True (deduct_credits 와 일관).
     """
     if os.environ.get("ENV", "").lower() == "test":
+        return True
+    if is_unlimited_active_by_id(user_id):
+        print(f"[check_user_credits] 무제한 플랜 기간 — 잔액 무시 (user={user_id})")
         return True
     current_credits = get_current_credits(user_id)
     return current_credits >= required_credits
@@ -95,11 +143,30 @@ def deduct_credits(user_id: str, amount: int = 1000, reason: str = "video_genera
     try:
         users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
         user_found = False
-        
+
+        # 무제한 플랜 기간이면 잔액을 건드리지 않는다.
+        # 단 사용량 추적(KPI/정산)을 위해 이력은 amount=0 으로 남긴다.
+        for user in users:
+            if user["id"] == user_id and is_unlimited_active(user):
+                print(f"[deduct_credits] 무제한 플랜 기간 — 차감 건너뜀 (user={user_id}, reason={reason})")
+                try:
+                    save_credit_record({
+                        "user_id": user_id,
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "change_type": "unlimited_use",
+                        "amount": 0,
+                        "reason": reason,
+                        "unlimited_end": user.get("unlimited_end"),
+                    })
+                except Exception as e:
+                    # 이력 저장 실패가 영상 생성을 막으면 안 된다
+                    print(f"[deduct_credits] 무제한 이력 저장 실패(무시): {e}")
+                return True
+
         for user in users:
             if user["id"] == user_id:
                 current_credits = user.get("credits", 0)
-                
+
                 if current_credits < amount:
                     print(f"[!] 크레딧 부족. 현재: {current_credits}, 필요: {amount}")
                     return False

--- a/auto_video_create_server/tests/test_unlimited_plan.py
+++ b/auto_video_create_server/tests/test_unlimited_plan.py
@@ -1,0 +1,139 @@
+"""무제한 플랜 — 단위 테스트.
+
+무제한 플랜: `unlimited_start` ~ `unlimited_end` (YYYY-MM-DD, 양끝 포함) 기간에는
+크레딧 잔액과 무관하게 생성 가능하고 차감도 하지 않는다. 구독과는 별도 관리.
+"""
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import account_service as acc  # noqa: E402
+
+
+def d(offset_days):
+    return (datetime.utcnow().date() + timedelta(days=offset_days)).strftime("%Y-%m-%d")
+
+
+class TestIsUnlimitedActive(unittest.TestCase):
+
+    def test_within_period(self):
+        self.assertTrue(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(-3), "unlimited_end": d(3)}
+        ))
+
+    def test_boundaries_inclusive(self):
+        today = d(0)
+        self.assertTrue(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": today, "unlimited_end": today}
+        ))
+
+    def test_before_start(self):
+        self.assertFalse(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(1), "unlimited_end": d(10)}
+        ))
+
+    def test_after_end(self):
+        self.assertFalse(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        ))
+
+    def test_missing_fields(self):
+        self.assertFalse(acc.is_unlimited_active({"id": "u"}))
+        self.assertFalse(acc.is_unlimited_active({"id": "u", "unlimited_start": d(-1)}))
+        self.assertFalse(acc.is_unlimited_active({"id": "u", "unlimited_end": d(1)}))
+
+    def test_malformed_dates_are_not_unlimited(self):
+        """형식 오류로 무제한이 열리면 과금 사고 — 반드시 False."""
+        for bad in ["2026/01/01", "내일", "", None, 20260101, "2026-13-45"]:
+            self.assertFalse(acc.is_unlimited_active(
+                {"id": "u", "unlimited_start": bad, "unlimited_end": d(3)}
+            ), f"start={bad!r} 이 무제한으로 처리됨")
+
+    def test_non_dict_safe(self):
+        self.assertFalse(acc.is_unlimited_active(None))
+        self.assertFalse(acc.is_unlimited_active("user"))
+
+
+class TestCheckUserCredits(unittest.TestCase):
+    """무제한이면 잔액 0 이어도 통과, 아니면 기존 규칙."""
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {"ENV": "production"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def _users(self, user):
+        return mock.patch.object(acc, "load_json_from_s3", return_value=[user])
+
+    def test_unlimited_passes_with_zero_credits(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with self._users(user):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+    def test_expired_unlimited_falls_back_to_credits(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        with self._users(user):
+            self.assertFalse(acc.check_user_credits("u", 1000))
+
+    def test_expired_unlimited_with_enough_credits_passes(self):
+        user = {"id": "u", "credits": 5000, "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        with self._users(user):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+    def test_no_unlimited_normal_rules(self):
+        with self._users({"id": "u", "credits": 999}):
+            self.assertFalse(acc.check_user_credits("u", 1000))
+        with self._users({"id": "u", "credits": 1000}):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+
+class TestDeductCredits(unittest.TestCase):
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {"ENV": "production"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_unlimited_does_not_touch_balance(self):
+        user = {"id": "u", "credits": 3000, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record") as rec, \
+             mock.patch.object(acc, "s3") as s3:
+            self.assertTrue(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 3000, "무제한인데 잔액이 차감됨")
+            s3.put_object.assert_not_called()
+            # 사용량 추적용 이력은 남긴다
+            rec.assert_called_once()
+            self.assertEqual(rec.call_args[0][0]["change_type"], "unlimited_use")
+            self.assertEqual(rec.call_args[0][0]["amount"], 0)
+
+    def test_history_failure_does_not_block_generation(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record", side_effect=Exception("S3 다운")), \
+             mock.patch.object(acc, "s3"):
+            self.assertTrue(acc.deduct_credits("u", 1000))
+
+    def test_normal_user_still_deducted(self):
+        user = {"id": "u", "credits": 3000}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record"), \
+             mock.patch.object(acc, "s3"):
+            self.assertTrue(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 2000)
+
+    def test_expired_unlimited_insufficient_is_rejected(self):
+        user = {"id": "u", "credits": 500, "unlimited_start": d(-9), "unlimited_end": d(-2)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record"), \
+             mock.patch.object(acc, "s3"):
+            self.assertFalse(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 500)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 새 플랜

`unlimited_start` ~ `unlimited_end` (YYYY-MM-DD, **양끝 포함**) 기간에는 **크레딧 잔액과 무관하게 무제한 생성**, 차감도 하지 않는다.

## 동작
| 상황 | 결과 |
|---|---|
| 무제한 기간 중 · 잔액 0 | ✅ 생성 가능, 잔액 그대로 |
| 무제한 기간 종료 후 | 기존 크레딧 정책으로 복귀 |
| 무제한 기간 시작 전 | 기존 크레딧 정책 |
| 날짜 누락/형식 오류 | **무제한 아님**으로 처리 (과금 사고 방지) |

- 사용량 추적: 이력에 `change_type="unlimited_use", amount=0` 기록 (KPI/정산용). 이력 저장이 실패해도 생성은 막지 않음
- **구독과는 별도 관리** (PO 확정). 단 구독 만료 시 로그인 자체가 막히므로, 관리 스크립트가 구독 종료일이 무제한 종료일보다 빠르면 경고 출력

## 운영 (manage_credits.py)
- `6. 무제한 플랜 설정` — 유저ID + 시작일 + 종료일
- `7. 무제한 플랜 해제`
- `1. 목록` 에 무제한 상태 표시 (`무제한중(~2026-12-31)` / `예정` / `만료`)

## 부수
`account_service.py` 에 `from __future__ import annotations` 추가 — 기존 PEP604 어노테이션 때문에 로컬 Python 3.9 에서 import 가 막혀 단위 테스트를 못 돌리던 문제 해소 (Lambda 3.11 동작 영향 없음).

테스트 15개 추가 / 전체 109개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)