### PR TITLE
feat: 비밀번호 변경 기능

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -11,6 +11,7 @@ import ZoomInIcon from '@mui/icons-material/ZoomIn';
 import EditIcon from '@mui/icons-material/Edit';
 import AuthGuard from "../components/AuthGuard";
 import LogoutButton from "../components/LogoutButton";
+import ChangePasswordButton from "../components/ChangePasswordButton";
 import SubtitleStyleEditor, { SubtitleSettings } from "./components/SubtitleStyleEditor";
 
 interface MediaList {
@@ -468,7 +469,10 @@ export default function Home() {
           </Box>
           <Box sx={{ display: "flex", gap: 1, alignItems: 'center' }}>
             {isLoggedIn ? (
-              <LogoutButton />
+              <>
+                <ChangePasswordButton />
+                <LogoutButton />
+              </>
             ) : (
               <>
                 <Button variant="outlined" color="inherit" size="small" sx={{ fontWeight: 600 }} onClick={() => handleBetaAlert("Beta 버전에서는 로그인 기능이 지원되지 않습니다.")}>로그인</Button>

--- a/auto_video_create_front/src/components/ChangePasswordButton.tsx
+++ b/auto_video_create_front/src/components/ChangePasswordButton.tsx
@@ -1,0 +1,159 @@
+"use client";
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Typography,
+  CircularProgress,
+  Snackbar,
+  Alert,
+} from "@mui/material";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function ChangePasswordButton() {
+  const [open, setOpen] = useState(false);
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [confirmPw, setConfirmPw] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState(false);
+
+  const reset = () => {
+    setCurrentPw("");
+    setNewPw("");
+    setConfirmPw("");
+    setError(null);
+    setLoading(false);
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setOpen(false);
+    reset();
+  };
+
+  // 서버에 보내기 전 로컬에서 걸러낼 수 있는 것만 검사한다 (현재 비밀번호 검증은 서버 몫).
+  const localError = (): string | null => {
+    if (!currentPw || !newPw || !confirmPw) return "모든 항목을 입력해주세요.";
+    if (newPw.length < MIN_PASSWORD_LENGTH) return `새 비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상이어야 해요.`;
+    if (newPw !== confirmPw) return "새 비밀번호가 서로 달라요.";
+    if (newPw === currentPw) return "새 비밀번호가 현재 비밀번호와 같아요.";
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const localMsg = localError();
+    if (localMsg) {
+      setError(localMsg);
+      return;
+    }
+    const userId = typeof window !== "undefined" ? localStorage.getItem("user_id") : null;
+    if (!userId) {
+      setError("로그인 정보를 찾을 수 없어요. 다시 로그인해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/account/change-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-USER-ID": userId },
+        body: JSON.stringify({ id: userId, current_pw: currentPw, new_pw: newPw }),
+      });
+      const data = await res.json().catch(() => null);
+      if (data?.status === "success") {
+        setOpen(false);
+        reset();
+        setToast(true);
+      } else {
+        setError(data?.reason || "비밀번호를 변경할 수 없어요.");
+        setLoading(false);
+      }
+    } catch {
+      setError("서버 요청 중 오류가 발생했어요.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        color="inherit"
+        size="small"
+        sx={{ fontWeight: 600, borderRadius: 2, px: 2, py: 0.5 }}
+        onClick={() => setOpen(true)}
+      >
+        비밀번호 변경
+      </Button>
+
+      <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700, fontSize: 18 }}>비밀번호 변경</DialogTitle>
+        <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+          <TextField
+            label="현재 비밀번호"
+            type="password"
+            size="small"
+            autoComplete="current-password"
+            value={currentPw}
+            onChange={(e) => setCurrentPw(e.target.value)}
+            disabled={loading}
+            autoFocus
+          />
+          <TextField
+            label="새 비밀번호"
+            type="password"
+            size="small"
+            autoComplete="new-password"
+            value={newPw}
+            onChange={(e) => setNewPw(e.target.value)}
+            disabled={loading}
+            helperText={`${MIN_PASSWORD_LENGTH}자 이상`}
+          />
+          <TextField
+            label="새 비밀번호 확인"
+            type="password"
+            size="small"
+            autoComplete="new-password"
+            value={confirmPw}
+            onChange={(e) => setConfirmPw(e.target.value)}
+            disabled={loading}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !loading) handleSubmit();
+            }}
+          />
+          {error && (
+            <Typography sx={{ color: "#d32f2f", fontSize: 13, wordBreak: "keep-all" }}>{error}</Typography>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleClose} disabled={loading}>
+            취소
+          </Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+            {loading ? <CircularProgress size={18} color="inherit" /> : "변경"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={toast}
+        autoHideDuration={3000}
+        onClose={() => setToast(false)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert severity="success" onClose={() => setToast(false)}>
+          비밀번호를 변경했어요.
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/auto_video_create_server/api/account.py
+++ b/auto_video_create_server/api/account.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
-from services.account_service import authenticate_user
+from services.account_service import authenticate_user, change_password, MIN_PASSWORD_LENGTH
 
 router = APIRouter()
 
@@ -23,4 +23,40 @@ def login(req: LoginRequest):
     if user:
         return LoginResponse(status="success", id=user["id"], subscription_start=user["subscription_start"], subscription_end=user["subscription_end"])
     else:
-        return LoginResponse(status="fail", reason="invalid credentials") 
+        return LoginResponse(status="fail", reason="invalid credentials")
+
+
+class ChangePasswordRequest(BaseModel):
+    id: str
+    current_pw: str
+    new_pw: str
+
+
+class ChangePasswordResponse(BaseModel):
+    status: str
+    reason: str = None
+
+
+# 결과 코드 → 사용자에게 보여줄 메시지 (해요체)
+_CHANGE_PW_MESSAGES = {
+    "invalid": "아이디 또는 현재 비밀번호가 올바르지 않아요.",
+    "same": "새 비밀번호가 현재 비밀번호와 같아요.",
+    "too_short": f"새 비밀번호는 {MIN_PASSWORD_LENGTH}자 이상이어야 해요.",
+    "error": "비밀번호를 변경할 수 없어요. 잠시 후 다시 시도해주세요.",
+}
+
+
+@router.post("/change-password", response_model=ChangePasswordResponse)
+def change_password_endpoint(req: ChangePasswordRequest):
+    """POST /api/account/change-password
+
+    현재 비밀번호를 검증한 뒤 새 비밀번호로 변경한다.
+    구독 만료 여부와 무관하게 변경 가능 (만료 계정도 비밀번호는 바꿀 수 있어야 함).
+    """
+    result = change_password(req.id, req.current_pw, req.new_pw)
+    if result == "success":
+        return ChangePasswordResponse(status="success")
+    return ChangePasswordResponse(
+        status="fail",
+        reason=_CHANGE_PW_MESSAGES.get(result, _CHANGE_PW_MESSAGES["error"]),
+    )

--- a/auto_video_create_server/services/account_service.py
+++ b/auto_video_create_server/services/account_service.py
@@ -1,3 +1,8 @@
+# PEP 604 (`dict | str | None`) 어노테이션이 Python 3.9 에서도 import 가능하도록
+# 어노테이션을 지연 평가한다. Lambda 는 3.11 이라 동작 영향 없고, 로컬(3.9)에서
+# 단위 테스트를 돌릴 수 있게 된다.
+from __future__ import annotations
+
 from utils.s3_utils import load_json_from_s3
 from datetime import datetime
 import boto3
@@ -16,6 +21,52 @@ def authenticate_user(user_id: str, pw: str) -> dict | str | None:
                 return "expired"
             return user
     return None
+
+MIN_PASSWORD_LENGTH = 8
+
+
+def change_password(user_id: str, current_pw: str, new_pw: str) -> str:
+    """비밀번호 변경. 현재 비밀번호가 맞아야 한다.
+
+    반환값:
+        "success"      변경 완료
+        "invalid"      사용자 없음 또는 현재 비밀번호 불일치 (구분해서 알려주지 않는다 — 계정 존재 여부 노출 방지)
+        "same"         새 비밀번호가 현재와 동일
+        "too_short"    새 비밀번호가 최소 길이 미만
+        "error"        S3 등 내부 오류
+
+    NOTE: 비밀번호는 현재 users.json 에 평문으로 저장된다(기존 구조 유지).
+    추후 해싱 도입 시 이 함수에서 해시 저장으로 바꾸고, authenticate_user 에서
+    "저장값이 해시면 해시 검증, 아니면 평문 비교 후 해시로 승격"하는 lazy migration
+    을 붙이면 기존 유저 영향 없이 전환할 수 있다.
+    비밀번호 값 자체는 절대 로그에 남기지 않는다.
+    """
+    if not isinstance(new_pw, str) or len(new_pw) < MIN_PASSWORD_LENGTH:
+        return "too_short"
+    if current_pw == new_pw:
+        return "same"
+
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        for user in users:
+            if user["id"] == user_id:
+                if user.get("pw") != current_pw:
+                    print(f"[change_password] 현재 비밀번호 불일치 (user={user_id})")
+                    return "invalid"
+                user["pw"] = new_pw
+                s3.put_object(
+                    Bucket=BUCKET_USERS,
+                    Key=KEY_USERS,
+                    Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+                )
+                print(f"[change_password] 변경 완료 (user={user_id})")
+                return "success"
+        print(f"[change_password] 사용자 없음 (user={user_id})")
+        return "invalid"
+    except Exception as e:
+        print(f"[change_password] 실패 (user={user_id}): {e}")
+        return "error"
+
 
 def get_user_if_active(user_id: str) -> dict | None:
     """사용자 존재 + 구독 활성 여부 확인.

--- a/auto_video_create_server/tests/test_change_password.py
+++ b/auto_video_create_server/tests/test_change_password.py
@@ -1,0 +1,105 @@
+"""비밀번호 변경 — 단위 테스트.
+
+현재 비밀번호 검증 후에만 변경되며, 실패 시 S3 저장이 일어나지 않아야 한다.
+(비밀번호는 현재 평문 저장 — 기존 구조 유지)
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import account_service as acc  # noqa: E402
+
+
+class ChangePasswordTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.users = [
+            {"id": "alice", "pw": "oldpassword1", "subscription_start": "2020-01-01",
+             "subscription_end": "2099-12-31"},
+            {"id": "bob", "pw": "bobsecret123", "subscription_start": "2020-01-01",
+             "subscription_end": "2020-12-31"},  # 만료 계정
+        ]
+        self.load = mock.patch.object(acc, "load_json_from_s3", return_value=self.users)
+        self.load.start(); self.addCleanup(self.load.stop)
+        self.s3 = mock.patch.object(acc, "s3").start(); self.addCleanup(mock.patch.stopall)
+
+    def _saved(self):
+        """put_object 로 저장된 users 를 파싱."""
+        import json
+        self.s3.put_object.assert_called_once()
+        return json.loads(self.s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+
+
+class TestSuccess(ChangePasswordTestCase):
+
+    def test_success_updates_password(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "brandnewpw9"), "success")
+        saved = self._saved()
+        self.assertEqual(next(u for u in saved if u["id"] == "alice")["pw"], "brandnewpw9")
+
+    def test_other_users_untouched(self):
+        acc.change_password("alice", "oldpassword1", "brandnewpw9")
+        saved = self._saved()
+        self.assertEqual(next(u for u in saved if u["id"] == "bob")["pw"], "bobsecret123")
+
+    def test_expired_subscription_can_still_change(self):
+        """구독이 만료돼도 비밀번호는 바꿀 수 있어야 한다."""
+        self.assertEqual(acc.change_password("bob", "bobsecret123", "bobnewpass1"), "success")
+
+
+class TestRejection(ChangePasswordTestCase):
+
+    def test_wrong_current_password(self):
+        self.assertEqual(acc.change_password("alice", "wrongpw12345", "brandnewpw9"), "invalid")
+        self.s3.put_object.assert_not_called()
+
+    def test_unknown_user(self):
+        self.assertEqual(acc.change_password("nobody", "whatever1234", "brandnewpw9"), "invalid")
+        self.s3.put_object.assert_not_called()
+
+    def test_unknown_user_and_wrong_pw_give_same_code(self):
+        """계정 존재 여부가 응답으로 드러나지 않아야 한다."""
+        a = acc.change_password("nobody", "x" * 12, "brandnewpw9")
+        b = acc.change_password("alice", "wrongpw12345", "brandnewpw9")
+        self.assertEqual(a, b)
+
+    def test_same_as_current(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "oldpassword1"), "same")
+        self.s3.put_object.assert_not_called()
+
+    def test_too_short(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "short"), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_min_length_boundary(self):
+        exactly_min = "a" * acc.MIN_PASSWORD_LENGTH
+        self.assertEqual(acc.change_password("alice", "oldpassword1", exactly_min), "success")
+
+    def test_one_below_min_rejected(self):
+        below = "a" * (acc.MIN_PASSWORD_LENGTH - 1)
+        self.assertEqual(acc.change_password("alice", "oldpassword1", below), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_non_string_new_pw(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", None), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_validation_runs_before_s3_read(self):
+        """짧은 비밀번호는 S3 조회조차 하지 않는다 (불필요한 I/O 방지)."""
+        acc.load_json_from_s3.reset_mock()
+        acc.change_password("alice", "oldpassword1", "x")
+        acc.load_json_from_s3.assert_not_called()
+
+
+class TestErrorHandling(ChangePasswordTestCase):
+
+    def test_s3_failure_returns_error(self):
+        self.s3.put_object.side_effect = Exception("S3 다운")
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "brandnewpw9"), "error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 기능
헤더 로그아웃 옆 **"비밀번호 변경"** 버튼 → 모달에서 현재/새/확인 입력 → 변경.

## 검증
| 조건 | 결과 |
|---|---|
| 현재 비밀번호 불일치 | 거부 (저장 없음) |
| 존재하지 않는 계정 | 불일치와 **동일 응답** (계정 존재 여부 비노출) |
| 새 비밀번호 8자 미만 | 거부 (S3 조회조차 안 함) |
| 현재와 동일 | 거부 |
| 구독 만료 계정 | **변경 가능** (로그인은 막혀도 비밀번호는 바꿀 수 있어야 함) |

## API
`POST /api/account/change-password` — `{id, current_pw, new_pw}` → `{status, reason?}`

## 부수
`account_service.py` 에 `from __future__ import annotations` — 기존 PEP604 어노테이션 때문에 로컬 Python 3.9 에서 테스트가 안 돌던 문제 해소 (Lambda 3.11 영향 없음).

테스트 13개 추가 / 전체 107개 통과.

## ⚠️ 비밀번호 평문 저장 (기존 구조 유지, PO 확정)
`users.json` 에 평문으로 저장됩니다. 해싱은 이번 범위 밖이나, 추후 도입 시
`change_password` 에서 해시 저장 + `authenticate_user` 에 lazy migration(저장값이 해시면 해시 검증, 아니면 평문 비교 후 해시로 승격)을 붙이면 **기존 유저 영향 없이** 전환 가능하도록 주석으로 경로를 남겨뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)