### PR TITLE
Release — 무제한 플랜 + 비밀번호 변경 (main → prod)

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -11,6 +11,7 @@ import ZoomInIcon from '@mui/icons-material/ZoomIn';
 import EditIcon from '@mui/icons-material/Edit';
 import AuthGuard from "../components/AuthGuard";
 import LogoutButton from "../components/LogoutButton";
+import ChangePasswordButton from "../components/ChangePasswordButton";
 import SubtitleStyleEditor, { SubtitleSettings } from "./components/SubtitleStyleEditor";
 
 interface MediaList {
@@ -468,7 +469,10 @@ export default function Home() {
           </Box>
           <Box sx={{ display: "flex", gap: 1, alignItems: 'center' }}>
             {isLoggedIn ? (
-              <LogoutButton />
+              <>
+                <ChangePasswordButton />
+                <LogoutButton />
+              </>
             ) : (
               <>
                 <Button variant="outlined" color="inherit" size="small" sx={{ fontWeight: 600 }} onClick={() => handleBetaAlert("Beta 버전에서는 로그인 기능이 지원되지 않습니다.")}>로그인</Button>

--- a/auto_video_create_front/src/components/ChangePasswordButton.tsx
+++ b/auto_video_create_front/src/components/ChangePasswordButton.tsx
@@ -1,0 +1,159 @@
+"use client";
+import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Typography,
+  CircularProgress,
+  Snackbar,
+  Alert,
+} from "@mui/material";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function ChangePasswordButton() {
+  const [open, setOpen] = useState(false);
+  const [currentPw, setCurrentPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+  const [confirmPw, setConfirmPw] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState(false);
+
+  const reset = () => {
+    setCurrentPw("");
+    setNewPw("");
+    setConfirmPw("");
+    setError(null);
+    setLoading(false);
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setOpen(false);
+    reset();
+  };
+
+  // 서버에 보내기 전 로컬에서 걸러낼 수 있는 것만 검사한다 (현재 비밀번호 검증은 서버 몫).
+  const localError = (): string | null => {
+    if (!currentPw || !newPw || !confirmPw) return "모든 항목을 입력해주세요.";
+    if (newPw.length < MIN_PASSWORD_LENGTH) return `새 비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상이어야 해요.`;
+    if (newPw !== confirmPw) return "새 비밀번호가 서로 달라요.";
+    if (newPw === currentPw) return "새 비밀번호가 현재 비밀번호와 같아요.";
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const localMsg = localError();
+    if (localMsg) {
+      setError(localMsg);
+      return;
+    }
+    const userId = typeof window !== "undefined" ? localStorage.getItem("user_id") : null;
+    if (!userId) {
+      setError("로그인 정보를 찾을 수 없어요. 다시 로그인해주세요.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/account/change-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-USER-ID": userId },
+        body: JSON.stringify({ id: userId, current_pw: currentPw, new_pw: newPw }),
+      });
+      const data = await res.json().catch(() => null);
+      if (data?.status === "success") {
+        setOpen(false);
+        reset();
+        setToast(true);
+      } else {
+        setError(data?.reason || "비밀번호를 변경할 수 없어요.");
+        setLoading(false);
+      }
+    } catch {
+      setError("서버 요청 중 오류가 발생했어요.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        color="inherit"
+        size="small"
+        sx={{ fontWeight: 600, borderRadius: 2, px: 2, py: 0.5 }}
+        onClick={() => setOpen(true)}
+      >
+        비밀번호 변경
+      </Button>
+
+      <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700, fontSize: 18 }}>비밀번호 변경</DialogTitle>
+        <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+          <TextField
+            label="현재 비밀번호"
+            type="password"
+            size="small"
+            autoComplete="current-password"
+            value={currentPw}
+            onChange={(e) => setCurrentPw(e.target.value)}
+            disabled={loading}
+            autoFocus
+          />
+          <TextField
+            label="새 비밀번호"
+            type="password"
+            size="small"
+            autoComplete="new-password"
+            value={newPw}
+            onChange={(e) => setNewPw(e.target.value)}
+            disabled={loading}
+            helperText={`${MIN_PASSWORD_LENGTH}자 이상`}
+          />
+          <TextField
+            label="새 비밀번호 확인"
+            type="password"
+            size="small"
+            autoComplete="new-password"
+            value={confirmPw}
+            onChange={(e) => setConfirmPw(e.target.value)}
+            disabled={loading}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !loading) handleSubmit();
+            }}
+          />
+          {error && (
+            <Typography sx={{ color: "#d32f2f", fontSize: 13, wordBreak: "keep-all" }}>{error}</Typography>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleClose} disabled={loading}>
+            취소
+          </Button>
+          <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+            {loading ? <CircularProgress size={18} color="inherit" /> : "변경"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={toast}
+        autoHideDuration={3000}
+        onClose={() => setToast(false)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert severity="success" onClose={() => setToast(false)}>
+          비밀번호를 변경했어요.
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/auto_video_create_server/api/account.py
+++ b/auto_video_create_server/api/account.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
-from services.account_service import authenticate_user
+from services.account_service import authenticate_user, change_password, MIN_PASSWORD_LENGTH
 
 router = APIRouter()
 
@@ -23,4 +23,40 @@ def login(req: LoginRequest):
     if user:
         return LoginResponse(status="success", id=user["id"], subscription_start=user["subscription_start"], subscription_end=user["subscription_end"])
     else:
-        return LoginResponse(status="fail", reason="invalid credentials") 
+        return LoginResponse(status="fail", reason="invalid credentials")
+
+
+class ChangePasswordRequest(BaseModel):
+    id: str
+    current_pw: str
+    new_pw: str
+
+
+class ChangePasswordResponse(BaseModel):
+    status: str
+    reason: str = None
+
+
+# 결과 코드 → 사용자에게 보여줄 메시지 (해요체)
+_CHANGE_PW_MESSAGES = {
+    "invalid": "아이디 또는 현재 비밀번호가 올바르지 않아요.",
+    "same": "새 비밀번호가 현재 비밀번호와 같아요.",
+    "too_short": f"새 비밀번호는 {MIN_PASSWORD_LENGTH}자 이상이어야 해요.",
+    "error": "비밀번호를 변경할 수 없어요. 잠시 후 다시 시도해주세요.",
+}
+
+
+@router.post("/change-password", response_model=ChangePasswordResponse)
+def change_password_endpoint(req: ChangePasswordRequest):
+    """POST /api/account/change-password
+
+    현재 비밀번호를 검증한 뒤 새 비밀번호로 변경한다.
+    구독 만료 여부와 무관하게 변경 가능 (만료 계정도 비밀번호는 바꿀 수 있어야 함).
+    """
+    result = change_password(req.id, req.current_pw, req.new_pw)
+    if result == "success":
+        return ChangePasswordResponse(status="success")
+    return ChangePasswordResponse(
+        status="fail",
+        reason=_CHANGE_PW_MESSAGES.get(result, _CHANGE_PW_MESSAGES["error"]),
+    )

--- a/auto_video_create_server/scripts/manage_credits.py
+++ b/auto_video_create_server/scripts/manage_credits.py
@@ -189,6 +189,86 @@ def set_initial_credits(user_id, amount, reason="initial_setup"):
         print(f"[!] 초기 크레딧 설정 실패: {e}")
         return False
 
+def _unlimited_status(user):
+    """무제한 플랜 상태 문자열. (BE is_unlimited_active 와 동일 규칙)"""
+    start, end = user.get("unlimited_start"), user.get("unlimited_end")
+    if not start or not end:
+        return "-"
+    try:
+        today = datetime.utcnow().date()
+        s = datetime.strptime(start, "%Y-%m-%d").date()
+        e = datetime.strptime(end, "%Y-%m-%d").date()
+    except ValueError:
+        return "형식오류"
+    if today < s:
+        return f"예정({start}~{end})"
+    if today > e:
+        return f"만료({end})"
+    return f"무제한중(~{end})"
+
+
+def set_unlimited_plan(user_id, start, end):
+    """무제한 플랜 기간 설정. 기간 중에는 크레딧 차감 없이 무제한 생성."""
+    try:
+        s = datetime.strptime(start, "%Y-%m-%d").date()
+        e = datetime.strptime(end, "%Y-%m-%d").date()
+    except ValueError:
+        print("[!] 날짜는 YYYY-MM-DD 형식으로 입력해주세요.")
+        return
+    if e < s:
+        print("[!] 종료일이 시작일보다 빠릅니다.")
+        return
+
+    users = download_users()
+    for user in users:
+        if user["id"] == user_id:
+            user["unlimited_start"] = start
+            user["unlimited_end"] = end
+            upload_users(users)
+            print(f"[*] {user_id} 무제한 플랜 설정: {start} ~ {end}")
+            # 구독 기간과는 별도 관리 — 구독이 만료돼 있으면 로그인 자체가 막히므로 경고만 한다.
+            sub_end = user.get("subscription_end")
+            try:
+                if sub_end and datetime.strptime(sub_end, "%Y-%m-%d").date() < e:
+                    print(f"[!] 주의: 구독 종료일({sub_end})이 무제한 종료일({end})보다 빠릅니다.")
+                    print("    구독이 만료되면 로그인 자체가 막혀 무제한도 쓸 수 없습니다.")
+                    print("    edit_users_json.py 의 '4. 구독일 변경' 으로 구독 기간을 함께 늘려주세요.")
+            except ValueError:
+                pass
+            save_credit_record({
+                "user_id": user_id,
+                "timestamp": datetime.utcnow().isoformat(),
+                "change_type": "unlimited_set",
+                "amount": 0,
+                "reason": f"unlimited_plan {start}~{end}",
+            })
+            return
+    print(f"[!] 사용자 {user_id}를 찾을 수 없습니다.")
+
+
+def clear_unlimited_plan(user_id):
+    """무제한 플랜 해제 (일반 크레딧 정책으로 복귀)."""
+    users = download_users()
+    for user in users:
+        if user["id"] == user_id:
+            if not user.get("unlimited_start") and not user.get("unlimited_end"):
+                print(f"[!] {user_id}는 무제한 플랜이 설정돼 있지 않습니다.")
+                return
+            user.pop("unlimited_start", None)
+            user.pop("unlimited_end", None)
+            upload_users(users)
+            print(f"[*] {user_id} 무제한 플랜 해제 완료. 이후 크레딧 차감 정상 적용.")
+            save_credit_record({
+                "user_id": user_id,
+                "timestamp": datetime.utcnow().isoformat(),
+                "change_type": "unlimited_clear",
+                "amount": 0,
+                "reason": "unlimited_plan cleared",
+            })
+            return
+    print(f"[!] 사용자 {user_id}를 찾을 수 없습니다.")
+
+
 def list_users_with_credits():
     """크레딧 정보와 함께 사용자 목록 출력"""
     users = download_users()
@@ -196,7 +276,8 @@ def list_users_with_credits():
     for i, user in enumerate(users):
         credits = user.get("credits", 0)
         blog_url = user.get('blog_url', '없음')
-        print(f"{i+1}. id: {user['id']}, 크레딧: {credits}, 구독: {user['subscription_start']} ~ {user['subscription_end']}, 블로그: {blog_url}")
+        unlimited = _unlimited_status(user)
+        print(f"{i+1}. id: {user['id']}, 크레딧: {credits}, 무제한: {unlimited}, 구독: {user['subscription_start']} ~ {user['subscription_end']}, 블로그: {blog_url}")
     print()
 
 def show_credit_history(user_id):
@@ -208,7 +289,10 @@ def show_credit_history(user_id):
     
     print(f"\n=== {user_id} 크레딧 변경 이력 (최근 20건) ===")
     for record in history:
-        change_type_kr = {"add": "추가", "deduct": "차감", "initial": "초기설정"}.get(record["change_type"], record["change_type"])
+        change_type_kr = {
+            "add": "추가", "deduct": "차감", "initial": "초기설정",
+            "unlimited_use": "무제한사용", "unlimited_set": "무제한설정", "unlimited_clear": "무제한해제",
+        }.get(record["change_type"], record["change_type"])
         print(f"{record['timestamp']} | {change_type_kr} | {record['amount']:+d} | {record['reason']}")
     print()
 
@@ -220,7 +304,9 @@ def main():
         print("3. 크레딧 차감")
         print("4. 초기 크레딧 설정")
         print("5. 크레딧 이력 보기")
-        print("6. 종료")
+        print("6. 무제한 플랜 설정 (기간 중 차감 없이 무제한 생성)")
+        print("7. 무제한 플랜 해제")
+        print("8. 종료")
         
         sel = input("선택: ").strip()
         
@@ -257,8 +343,18 @@ def main():
         elif sel == "5":
             user_id = input("사용자 ID: ").strip()
             show_credit_history(user_id)
-            
+
         elif sel == "6":
+            user_id = input("사용자 ID: ").strip()
+            start = input("무제한 시작일(YYYY-MM-DD): ").strip()
+            end = input("무제한 종료일(YYYY-MM-DD): ").strip()
+            set_unlimited_plan(user_id, start, end)
+
+        elif sel == "7":
+            user_id = input("사용자 ID: ").strip()
+            clear_unlimited_plan(user_id)
+
+        elif sel == "8":
             print("종료합니다.")
             break
             

--- a/auto_video_create_server/services/account_service.py
+++ b/auto_video_create_server/services/account_service.py
@@ -1,8 +1,52 @@
+# PEP 604 (`dict | str | None`) 어노테이션이 Python 3.9 에서도 import 가능하도록
+# 어노테이션을 지연 평가한다. Lambda 는 3.11 이라 동작에 영향 없고, 로컬(3.9)에서
+# 단위 테스트를 돌릴 수 있게 된다.
+from __future__ import annotations
+
 from utils.s3_utils import load_json_from_s3
 from datetime import datetime
 import boto3
 import json
 import os
+
+def _parse_date(value):
+    """YYYY-MM-DD 문자열 → date. 형식이 아니면 None (기존 구독 검증과 동일 포맷)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def is_unlimited_active(user: dict) -> bool:
+    """무제한 플랜 기간 중인지 판정 (user dict 기준, S3 재조회 없음).
+
+    무제한 플랜: `unlimited_start` ~ `unlimited_end` (YYYY-MM-DD, 양끝 포함) 사이에는
+    크레딧 잔액과 무관하게 영상을 생성할 수 있고 차감도 하지 않는다.
+
+    - 구독 기간과는 **별개로 관리**한다 (PO 확정 2026-08-05). 단 구독이 만료되면
+      로그인 자체가 막히므로, 무제한을 부여할 때 구독 기간도 함께 열어둬야 한다.
+    - 두 날짜 중 하나라도 없거나 형식이 잘못되면 무제한 아님(False)으로 안전 처리.
+    """
+    if not isinstance(user, dict):
+        return False
+    start = _parse_date(user.get("unlimited_start"))
+    end = _parse_date(user.get("unlimited_end"))
+    if start is None or end is None:
+        return False
+    today = datetime.utcnow().date()
+    return start <= today <= end
+
+
+def is_unlimited_active_by_id(user_id: str) -> bool:
+    """user_id 로 무제한 여부 조회 (S3 조회 포함)."""
+    users = load_json_from_s3("blog-to-short-form-users", "users.json")
+    for user in users:
+        if user["id"] == user_id:
+            return is_unlimited_active(user)
+    return False
+
 
 def authenticate_user(user_id: str, pw: str) -> dict | str | None:
     users = load_json_from_s3("blog-to-short-form-users", "users.json")
@@ -64,8 +108,12 @@ def check_user_credits(user_id: str, required_credits: int = 1000) -> bool:
     """사용자의 크레딧이 충분한지 체크.
 
     cycle-2 (ADR-6): ENV=test 환경에서는 항상 True (deduct_credits 와 일관).
+    무제한 플랜 기간 중이면 잔액과 무관하게 True (deduct_credits 와 일관).
     """
     if os.environ.get("ENV", "").lower() == "test":
+        return True
+    if is_unlimited_active_by_id(user_id):
+        print(f"[check_user_credits] 무제한 플랜 기간 — 잔액 무시 (user={user_id})")
         return True
     current_credits = get_current_credits(user_id)
     return current_credits >= required_credits
@@ -95,11 +143,30 @@ def deduct_credits(user_id: str, amount: int = 1000, reason: str = "video_genera
     try:
         users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
         user_found = False
-        
+
+        # 무제한 플랜 기간이면 잔액을 건드리지 않는다.
+        # 단 사용량 추적(KPI/정산)을 위해 이력은 amount=0 으로 남긴다.
+        for user in users:
+            if user["id"] == user_id and is_unlimited_active(user):
+                print(f"[deduct_credits] 무제한 플랜 기간 — 차감 건너뜀 (user={user_id}, reason={reason})")
+                try:
+                    save_credit_record({
+                        "user_id": user_id,
+                        "timestamp": datetime.utcnow().isoformat(),
+                        "change_type": "unlimited_use",
+                        "amount": 0,
+                        "reason": reason,
+                        "unlimited_end": user.get("unlimited_end"),
+                    })
+                except Exception as e:
+                    # 이력 저장 실패가 영상 생성을 막으면 안 된다
+                    print(f"[deduct_credits] 무제한 이력 저장 실패(무시): {e}")
+                return True
+
         for user in users:
             if user["id"] == user_id:
                 current_credits = user.get("credits", 0)
-                
+
                 if current_credits < amount:
                     print(f"[!] 크레딧 부족. 현재: {current_credits}, 필요: {amount}")
                     return False

--- a/auto_video_create_server/services/account_service.py
+++ b/auto_video_create_server/services/account_service.py
@@ -1,3 +1,8 @@
+# PEP 604 (`dict | str | None`) 어노테이션이 Python 3.9 에서도 import 가능하도록
+# 어노테이션을 지연 평가한다. Lambda 는 3.11 이라 동작 영향 없고, 로컬(3.9)에서
+# 단위 테스트를 돌릴 수 있게 된다.
+from __future__ import annotations
+
 from utils.s3_utils import load_json_from_s3
 from datetime import datetime
 import boto3
@@ -16,6 +21,52 @@ def authenticate_user(user_id: str, pw: str) -> dict | str | None:
                 return "expired"
             return user
     return None
+
+MIN_PASSWORD_LENGTH = 8
+
+
+def change_password(user_id: str, current_pw: str, new_pw: str) -> str:
+    """비밀번호 변경. 현재 비밀번호가 맞아야 한다.
+
+    반환값:
+        "success"      변경 완료
+        "invalid"      사용자 없음 또는 현재 비밀번호 불일치 (구분해서 알려주지 않는다 — 계정 존재 여부 노출 방지)
+        "same"         새 비밀번호가 현재와 동일
+        "too_short"    새 비밀번호가 최소 길이 미만
+        "error"        S3 등 내부 오류
+
+    NOTE: 비밀번호는 현재 users.json 에 평문으로 저장된다(기존 구조 유지).
+    추후 해싱 도입 시 이 함수에서 해시 저장으로 바꾸고, authenticate_user 에서
+    "저장값이 해시면 해시 검증, 아니면 평문 비교 후 해시로 승격"하는 lazy migration
+    을 붙이면 기존 유저 영향 없이 전환할 수 있다.
+    비밀번호 값 자체는 절대 로그에 남기지 않는다.
+    """
+    if not isinstance(new_pw, str) or len(new_pw) < MIN_PASSWORD_LENGTH:
+        return "too_short"
+    if current_pw == new_pw:
+        return "same"
+
+    try:
+        users = load_json_from_s3(BUCKET_USERS, KEY_USERS)
+        for user in users:
+            if user["id"] == user_id:
+                if user.get("pw") != current_pw:
+                    print(f"[change_password] 현재 비밀번호 불일치 (user={user_id})")
+                    return "invalid"
+                user["pw"] = new_pw
+                s3.put_object(
+                    Bucket=BUCKET_USERS,
+                    Key=KEY_USERS,
+                    Body=json.dumps(users, ensure_ascii=False, indent=2).encode("utf-8"),
+                )
+                print(f"[change_password] 변경 완료 (user={user_id})")
+                return "success"
+        print(f"[change_password] 사용자 없음 (user={user_id})")
+        return "invalid"
+    except Exception as e:
+        print(f"[change_password] 실패 (user={user_id}): {e}")
+        return "error"
+
 
 def get_user_if_active(user_id: str) -> dict | None:
     """사용자 존재 + 구독 활성 여부 확인.

--- a/auto_video_create_server/tests/test_change_password.py
+++ b/auto_video_create_server/tests/test_change_password.py
@@ -1,0 +1,105 @@
+"""비밀번호 변경 — 단위 테스트.
+
+현재 비밀번호 검증 후에만 변경되며, 실패 시 S3 저장이 일어나지 않아야 한다.
+(비밀번호는 현재 평문 저장 — 기존 구조 유지)
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import account_service as acc  # noqa: E402
+
+
+class ChangePasswordTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.users = [
+            {"id": "alice", "pw": "oldpassword1", "subscription_start": "2020-01-01",
+             "subscription_end": "2099-12-31"},
+            {"id": "bob", "pw": "bobsecret123", "subscription_start": "2020-01-01",
+             "subscription_end": "2020-12-31"},  # 만료 계정
+        ]
+        self.load = mock.patch.object(acc, "load_json_from_s3", return_value=self.users)
+        self.load.start(); self.addCleanup(self.load.stop)
+        self.s3 = mock.patch.object(acc, "s3").start(); self.addCleanup(mock.patch.stopall)
+
+    def _saved(self):
+        """put_object 로 저장된 users 를 파싱."""
+        import json
+        self.s3.put_object.assert_called_once()
+        return json.loads(self.s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+
+
+class TestSuccess(ChangePasswordTestCase):
+
+    def test_success_updates_password(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "brandnewpw9"), "success")
+        saved = self._saved()
+        self.assertEqual(next(u for u in saved if u["id"] == "alice")["pw"], "brandnewpw9")
+
+    def test_other_users_untouched(self):
+        acc.change_password("alice", "oldpassword1", "brandnewpw9")
+        saved = self._saved()
+        self.assertEqual(next(u for u in saved if u["id"] == "bob")["pw"], "bobsecret123")
+
+    def test_expired_subscription_can_still_change(self):
+        """구독이 만료돼도 비밀번호는 바꿀 수 있어야 한다."""
+        self.assertEqual(acc.change_password("bob", "bobsecret123", "bobnewpass1"), "success")
+
+
+class TestRejection(ChangePasswordTestCase):
+
+    def test_wrong_current_password(self):
+        self.assertEqual(acc.change_password("alice", "wrongpw12345", "brandnewpw9"), "invalid")
+        self.s3.put_object.assert_not_called()
+
+    def test_unknown_user(self):
+        self.assertEqual(acc.change_password("nobody", "whatever1234", "brandnewpw9"), "invalid")
+        self.s3.put_object.assert_not_called()
+
+    def test_unknown_user_and_wrong_pw_give_same_code(self):
+        """계정 존재 여부가 응답으로 드러나지 않아야 한다."""
+        a = acc.change_password("nobody", "x" * 12, "brandnewpw9")
+        b = acc.change_password("alice", "wrongpw12345", "brandnewpw9")
+        self.assertEqual(a, b)
+
+    def test_same_as_current(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "oldpassword1"), "same")
+        self.s3.put_object.assert_not_called()
+
+    def test_too_short(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "short"), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_min_length_boundary(self):
+        exactly_min = "a" * acc.MIN_PASSWORD_LENGTH
+        self.assertEqual(acc.change_password("alice", "oldpassword1", exactly_min), "success")
+
+    def test_one_below_min_rejected(self):
+        below = "a" * (acc.MIN_PASSWORD_LENGTH - 1)
+        self.assertEqual(acc.change_password("alice", "oldpassword1", below), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_non_string_new_pw(self):
+        self.assertEqual(acc.change_password("alice", "oldpassword1", None), "too_short")
+        self.s3.put_object.assert_not_called()
+
+    def test_validation_runs_before_s3_read(self):
+        """짧은 비밀번호는 S3 조회조차 하지 않는다 (불필요한 I/O 방지)."""
+        acc.load_json_from_s3.reset_mock()
+        acc.change_password("alice", "oldpassword1", "x")
+        acc.load_json_from_s3.assert_not_called()
+
+
+class TestErrorHandling(ChangePasswordTestCase):
+
+    def test_s3_failure_returns_error(self):
+        self.s3.put_object.side_effect = Exception("S3 다운")
+        self.assertEqual(acc.change_password("alice", "oldpassword1", "brandnewpw9"), "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auto_video_create_server/tests/test_unlimited_plan.py
+++ b/auto_video_create_server/tests/test_unlimited_plan.py
@@ -1,0 +1,139 @@
+"""무제한 플랜 — 단위 테스트.
+
+무제한 플랜: `unlimited_start` ~ `unlimited_end` (YYYY-MM-DD, 양끝 포함) 기간에는
+크레딧 잔액과 무관하게 생성 가능하고 차감도 하지 않는다. 구독과는 별도 관리.
+"""
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import account_service as acc  # noqa: E402
+
+
+def d(offset_days):
+    return (datetime.utcnow().date() + timedelta(days=offset_days)).strftime("%Y-%m-%d")
+
+
+class TestIsUnlimitedActive(unittest.TestCase):
+
+    def test_within_period(self):
+        self.assertTrue(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(-3), "unlimited_end": d(3)}
+        ))
+
+    def test_boundaries_inclusive(self):
+        today = d(0)
+        self.assertTrue(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": today, "unlimited_end": today}
+        ))
+
+    def test_before_start(self):
+        self.assertFalse(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(1), "unlimited_end": d(10)}
+        ))
+
+    def test_after_end(self):
+        self.assertFalse(acc.is_unlimited_active(
+            {"id": "u", "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        ))
+
+    def test_missing_fields(self):
+        self.assertFalse(acc.is_unlimited_active({"id": "u"}))
+        self.assertFalse(acc.is_unlimited_active({"id": "u", "unlimited_start": d(-1)}))
+        self.assertFalse(acc.is_unlimited_active({"id": "u", "unlimited_end": d(1)}))
+
+    def test_malformed_dates_are_not_unlimited(self):
+        """형식 오류로 무제한이 열리면 과금 사고 — 반드시 False."""
+        for bad in ["2026/01/01", "내일", "", None, 20260101, "2026-13-45"]:
+            self.assertFalse(acc.is_unlimited_active(
+                {"id": "u", "unlimited_start": bad, "unlimited_end": d(3)}
+            ), f"start={bad!r} 이 무제한으로 처리됨")
+
+    def test_non_dict_safe(self):
+        self.assertFalse(acc.is_unlimited_active(None))
+        self.assertFalse(acc.is_unlimited_active("user"))
+
+
+class TestCheckUserCredits(unittest.TestCase):
+    """무제한이면 잔액 0 이어도 통과, 아니면 기존 규칙."""
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {"ENV": "production"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def _users(self, user):
+        return mock.patch.object(acc, "load_json_from_s3", return_value=[user])
+
+    def test_unlimited_passes_with_zero_credits(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with self._users(user):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+    def test_expired_unlimited_falls_back_to_credits(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        with self._users(user):
+            self.assertFalse(acc.check_user_credits("u", 1000))
+
+    def test_expired_unlimited_with_enough_credits_passes(self):
+        user = {"id": "u", "credits": 5000, "unlimited_start": d(-10), "unlimited_end": d(-1)}
+        with self._users(user):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+    def test_no_unlimited_normal_rules(self):
+        with self._users({"id": "u", "credits": 999}):
+            self.assertFalse(acc.check_user_credits("u", 1000))
+        with self._users({"id": "u", "credits": 1000}):
+            self.assertTrue(acc.check_user_credits("u", 1000))
+
+
+class TestDeductCredits(unittest.TestCase):
+
+    def setUp(self):
+        self.env = mock.patch.dict(os.environ, {"ENV": "production"})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+
+    def test_unlimited_does_not_touch_balance(self):
+        user = {"id": "u", "credits": 3000, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record") as rec, \
+             mock.patch.object(acc, "s3") as s3:
+            self.assertTrue(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 3000, "무제한인데 잔액이 차감됨")
+            s3.put_object.assert_not_called()
+            # 사용량 추적용 이력은 남긴다
+            rec.assert_called_once()
+            self.assertEqual(rec.call_args[0][0]["change_type"], "unlimited_use")
+            self.assertEqual(rec.call_args[0][0]["amount"], 0)
+
+    def test_history_failure_does_not_block_generation(self):
+        user = {"id": "u", "credits": 0, "unlimited_start": d(-1), "unlimited_end": d(1)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record", side_effect=Exception("S3 다운")), \
+             mock.patch.object(acc, "s3"):
+            self.assertTrue(acc.deduct_credits("u", 1000))
+
+    def test_normal_user_still_deducted(self):
+        user = {"id": "u", "credits": 3000}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record"), \
+             mock.patch.object(acc, "s3"):
+            self.assertTrue(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 2000)
+
+    def test_expired_unlimited_insufficient_is_rejected(self):
+        user = {"id": "u", "credits": 500, "unlimited_start": d(-9), "unlimited_end": d(-2)}
+        with mock.patch.object(acc, "load_json_from_s3", return_value=[user]), \
+             mock.patch.object(acc, "save_credit_record"), \
+             mock.patch.object(acc, "s3"):
+            self.assertFalse(acc.deduct_credits("u", 1000))
+            self.assertEqual(user["credits"], 500)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 릴리즈 범위

### 무제한 플랜 (#60)
`unlimited_start` ~ `unlimited_end` 기간에는 **크레딧 잔액과 무관하게 무제한 생성**, 차감 없음.
- 날짜 누락/형식 오류는 "무제한 아님"으로 안전 처리 (과금 사고 방지)
- 사용량은 이력에 `unlimited_use`(amount 0)로 기록 — KPI/정산용
- 구독과 별도 관리. 관리 스크립트가 구독 종료일이 더 빠르면 경고 출력
- 운영: `manage_credits.py` → `6. 무제한 설정` / `7. 해제`, 목록에 상태 표시

### 비밀번호 변경 (#61)
헤더 "비밀번호 변경" 버튼 + 모달. 현재 비밀번호 검증 후 변경.
- 최소 8자 / 현재와 동일 거부 / 검증 실패 시 저장 없음
- 없는 계정과 비밀번호 불일치를 **동일 응답**으로 처리 (계정 존재 여부 비노출)
- 구독 만료 계정도 변경 가능
- API: `POST /api/account/change-password`

### 부수
`account_service.py` 에 `from __future__ import annotations` — 로컬(3.9)에서 단위 테스트가 안 돌던 문제 해소 (Lambda 3.11 영향 없음)

## 배포 영향
- BE: prod Lambda 자동 배포 (인증/크레딧 경로 변경 — 기존 유저 동작은 불변)
- FE: Amplify prod 빌드 (헤더 버튼 추가)
- 데이터 마이그레이션 불필요 — `unlimited_*` 필드가 없으면 기존 크레딧 정책 그대로

테스트 122개 통과.

## ⚠️ 남은 보안 이슈
비밀번호는 `users.json` 에 **평문 저장** (기존 구조 유지, PO 확정). 추후 해싱 도입 시 lazy migration 경로를 코드 주석에 남겨둠.

🤖 Generated with [Claude Code](https://claude.com/claude-code)