### PR TITLE
feat: TTS 를 Supertone → Typecast 로 전환

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -56,6 +56,12 @@ function parseSuggestedSections(raw: unknown, expectedLength: number): Suggested
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
+// 영상 생성이 실패했을 때 사용자가 다음에 뭘 해야 할지 알려준다.
+// (외부 서비스 장애·결제 문제 등은 사용자가 스스로 해결할 수 없으므로 관리자 문의로 안내)
+const ADMIN_CONTACT_GUIDE = "잠시 후 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요.";
+const withContactGuide = (message?: string | null) =>
+  `${(message || "").trim() || "영상 생성에 실패했어요."} ${ADMIN_CONTACT_GUIDE}`;
+
 const getProxiedImageUrl = (url: string) => `/api/image-proxy?url=${encodeURIComponent(url)}`;
 
 // 공통 fetch wrapper 함수 추가
@@ -338,7 +344,7 @@ export default function Home() {
         setError(data.message || "이미지/영상/스크립트 추출에 실패했습니다.");
       }
     } catch {
-      setError("서버 요청 중 오류가 발생했습니다.");
+      setError(withContactGuide("서버 요청 중 오류가 생겼어요."));
     } finally {
       setLoading(false);
     }
@@ -380,7 +386,7 @@ export default function Home() {
             videoUrl = pollData.url;
             break;
           } else if (pollData.status === "failed") {
-            setGenerateError("영상 생성에 실패했습니다.");
+            setGenerateError(withContactGuide("영상 합성 중 문제가 생겼어요."));
             setStep('select');
             return;
           }
@@ -391,15 +397,17 @@ export default function Home() {
           setVideoUrl(videoUrl);
           setStep('done');
         } else {
-          setGenerateError("영상 생성이 제한 시간 내에 완료되지 않았습니다.");
+          setGenerateError(withContactGuide("영상 생성이 제한 시간 내에 끝나지 않았어요."));
           setStep('select');
         }
       } else {
-        setGenerateError(data.message || "영상 생성에 실패했습니다.");
+        // BE 가 내려준 사유(예: 음성 생성 실패, 템플릿 미설정)를 그대로 보여주고
+        // 사용자가 할 수 있는 다음 행동을 덧붙인다.
+        setGenerateError(withContactGuide(data.message));
         setStep('select');
       }
     } catch {
-      setGenerateError("서버 요청 중 오류가 발생했습니다.");
+      setGenerateError(withContactGuide("서버 요청 중 오류가 생겼어요."));
       setStep('select');
     }
   };
@@ -606,6 +614,16 @@ export default function Home() {
                     </Button>
                   </Box>
                 </Box>
+                {/* 영상 생성 실패 안내 (PC).
+                    기존에는 이 배너가 모바일 분기에만 있어, PC 에서는 실패해도
+                    아무 설명 없이 select 화면으로 돌아와 "반응 없음"처럼 보였다. */}
+                {generateError && (
+                  <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
+                    <Alert severity="error" onClose={() => setGenerateError(null)}>
+                      {generateError}
+                    </Alert>
+                  </Box>
+                )}
                 {/* cycle-3: 자막 스타일 설정 (Row 1 — 접힘 기본) */}
                 <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
                   <SubtitleStyleEditor onSettingsChange={setSubtitleSettings} />
@@ -1039,7 +1057,11 @@ export default function Home() {
                 >
                   최종 영상 생성하기
                 </Button>
-                {generateError && <Typography color="error" sx={{ mb: 2 }}>{generateError}</Typography>}
+                {generateError && (
+                  <Alert severity="error" sx={{ mb: 2 }} onClose={() => setGenerateError(null)}>
+                    {generateError}
+                  </Alert>
+                )}
               </Box>
             )
           )}

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -3,7 +3,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from services.blog_shorts import extract_blog_content, get_blog_media_and_scripts
 from services.summarize import summarize_for_shorts_sets
-from services.tts_supertone import tts_with_supertone_multi
+from services.tts_typecast import (
+    tts_with_typecast_multi,
+    TypecastError,
+    DEFAULT_VOICE_ID as DEFAULT_TYPECAST_VOICE_ID,
+)
 from services.create_creatomate_video import create_creatomate_video, get_creatomate_vars, poll_creatomate_video_url
 from services.account_service import get_user_if_active, check_user_credits, get_current_credits
 from services.ai_background import generate_backgrounds_parallel, FALLBACK_URL as DEFAULT_BG_FALLBACK_URL
@@ -283,15 +287,15 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
             req.scene_count if req.scene_count is not None else len(req.scripts)
         )
 
-        # 1. TTS 변환 (scripts → mp3 url)
-        SUPERTONE_API_KEY = os.environ.get("SUPERTONE_API_KEY")
-        SUPERTONE_VOICE_ID = "c9220df3a5a70647d7b022"
-        SUPERTONE_SPEED = 1.4
-        audio_local_paths, audio_urls = tts_with_supertone_multi(
+        # 1. TTS 변환 (scripts → mp3 url) — 2026-08-05 Supertone → Typecast 전환
+        TYPECAST_API_KEY = os.environ.get("TYPECAST_API_KEY")
+        TYPECAST_VOICE_ID = os.environ.get("TYPECAST_VOICE_ID", DEFAULT_TYPECAST_VOICE_ID)
+        TTS_SPEED = 1.4
+        audio_local_paths, audio_urls = tts_with_typecast_multi(
             req.scripts,
-            api_key=SUPERTONE_API_KEY,
-            voice_id=SUPERTONE_VOICE_ID,
-            speed=SUPERTONE_SPEED
+            api_key=TYPECAST_API_KEY,
+            voice_id=TYPECAST_VOICE_ID,
+            speed=TTS_SPEED,
         )
         audio_local_paths = audio_local_paths[:scene_count]
         audio_urls = audio_urls[:scene_count]
@@ -375,6 +379,16 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
 
         poll_url = f"https://api.creatomate.com/v1/renders/{render_id}"
         return {"status": "started", "render_id": render_id, "poll_url": poll_url}
+    except TypecastError as e:
+        # 음성 생성 실패 — 사용자에게 보여줄 수 있는 메시지를 그대로 전달.
+        # (API 키 잔액 소진/한도 초과 등이 여기로 온다)
+        print("[generate_video] TTS 실패:", e)
+        return {
+            "status": "error",
+            "error_code": "tts_failed",
+            "message": f"음성을 만들지 못했어요. {e}",
+            "error_type": "tts_failed",
+        }
     except Exception as e:
         print("[generate_video 에러]", e)
         return {"status": "error", "message": str(e)}

--- a/auto_video_create_server/services/tts_typecast.py
+++ b/auto_video_create_server/services/tts_typecast.py
@@ -1,0 +1,139 @@
+"""Typecast TTS — Supertone 대체 (2026-08-05).
+
+Typecast API 는 Supertone 과 마찬가지로 **동기식**이며 오디오 바이트를 바로 반환하므로
+호출부 인터페이스(tts_with_*_multi)를 그대로 유지한다.
+
+API 요약 (https://typecast.ai/docs/ko/api-reference/text-to-speech/text-to-speech):
+    POST https://api.typecast.ai/v1/text-to-speech
+    헤더: X-API-KEY
+    본문: voice_id(tc_/uc_ 접두), text(1~2000자), model(ssfm-v30|ssfm-v21),
+          output.audio_format(wav|mp3), output.audio_tempo(0.5~2.0)
+    응답: 원본 오디오 바이트 (mp3 요청 시 audio/mpeg)
+"""
+import os
+import time
+
+import boto3
+import requests
+
+TYPECAST_URL = "https://api.typecast.ai/v1/text-to-speech"
+DEFAULT_MODEL = "ssfm-v30"
+DEFAULT_VOICE_ID = "tc_62e8f21e979b3860fe2f6a24"
+
+# Typecast text 제약: 1~2000자
+MAX_TEXT_LENGTH = 2000
+# audio_tempo 허용 범위
+MIN_TEMPO, MAX_TEMPO = 0.5, 2.0
+
+# Lambda 전체 예산이 30초라 한 호출이 오래 붙잡히면 안 된다. (연결, 응답) 초.
+REQUEST_TIMEOUT = (5, 15)
+# 일시적 오류(429/5xx)만 1회 재시도 — 예산을 크게 넘기지 않는 선에서.
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+RETRY_BACKOFF_SEC = 1.0
+
+S3_BUCKET = "auto-video-tts-files"
+
+
+class TypecastError(Exception):
+    """Typecast TTS 실패. 메시지는 사용자에게 노출될 수 있으므로 키를 담지 않는다."""
+
+
+def upload_to_s3(local_path, bucket, s3_key):
+    s3 = boto3.client("s3")
+    s3.upload_file(local_path, bucket, s3_key)
+    return f"https://{bucket}.s3.amazonaws.com/{s3_key}"
+
+
+def _clamp_tempo(speed):
+    try:
+        tempo = float(speed)
+    except (TypeError, ValueError):
+        return 1.0
+    return max(MIN_TEMPO, min(MAX_TEMPO, tempo))
+
+
+def tts_with_typecast(text, output_path, api_key, voice_id=None, speed=1.4,
+                      model=DEFAULT_MODEL, language="kor"):
+    """텍스트 1건 → mp3 파일. 성공 시 (output_path, None) 반환."""
+    if not api_key:
+        raise TypecastError("TYPECAST_API_KEY 가 설정되지 않았습니다.")
+
+    text = (text or "").strip()
+    if not text:
+        # 빈 스크립트는 Typecast 가 422 로 거절한다(최소 1자). 장면↔오디오 인덱스가
+        # 어긋나면 영상이 통째로 망가지므로, 조용히 넘기지 않고 명확히 실패시킨다.
+        raise TypecastError("스크립트가 비어 있어 음성을 만들 수 없어요. 해당 스크립트를 채워주세요.")
+    if len(text) > MAX_TEXT_LENGTH:
+        text = text[:MAX_TEXT_LENGTH]
+
+    payload = {
+        "voice_id": voice_id or DEFAULT_VOICE_ID,
+        "text": text,
+        "model": model,
+        "language": language,
+        "output": {
+            "audio_format": "mp3",
+            "audio_tempo": _clamp_tempo(speed),
+        },
+    }
+    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+
+    last_error = None
+    for attempt in range(2):  # 최초 1회 + 재시도 1회
+        try:
+            response = requests.post(
+                TYPECAST_URL, headers=headers, json=payload, timeout=REQUEST_TIMEOUT
+            )
+        except requests.RequestException as e:
+            last_error = f"Typecast 요청 실패: {e}"
+            if attempt == 0:
+                time.sleep(RETRY_BACKOFF_SEC)
+                continue
+            raise TypecastError(last_error)
+
+        if response.status_code == 200:
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+            return output_path, None
+
+        # 실패 — 본문에서 사유만 뽑아 로그/에러에 남긴다 (키는 절대 남기지 않음)
+        detail = ""
+        try:
+            body = response.json()
+            detail = body.get("detail") or body.get("message") or body.get("error_code") or ""
+        except Exception:
+            detail = (response.text or "")[:200]
+        last_error = f"Typecast {response.status_code}: {detail}".strip()
+        print(f"[tts_typecast] {last_error}")
+
+        if response.status_code in RETRY_STATUSES and attempt == 0:
+            time.sleep(RETRY_BACKOFF_SEC)
+            continue
+        raise TypecastError(last_error)
+
+    raise TypecastError(last_error or "Typecast 호출 실패")
+
+
+def tts_with_typecast_multi(scripts, api_key, voice_id=None, speed=1.4,
+                            output_dir="/tmp/tts_outputs"):
+    """스크립트 N개 → mp3 N개 생성 후 S3 업로드.
+
+    반환: (로컬 경로 리스트, S3 URL 리스트) — 기존 Supertone 함수와 동일 시그니처.
+    """
+    print(f"tts_with_typecast_multi 호출 (scripts={len(scripts)})")
+    os.makedirs(output_dir, exist_ok=True)
+    audio_local_paths = []
+    audio_urls = []
+
+    for idx, item in enumerate(scripts, 1):
+        text = item["script"] if isinstance(item, dict) else item
+        output_path = os.path.join(output_dir, f"shorts_script_{idx}.mp3")
+        local_path, _ = tts_with_typecast(
+            text, output_path, api_key, voice_id=voice_id, speed=speed
+        )
+        audio_local_paths.append(local_path)
+        ms = int(time.time() * 1000)
+        s3_key = f"shorts_script_{idx}_{ms}.mp3"
+        audio_urls.append(upload_to_s3(local_path, S3_BUCKET, s3_key))
+
+    return audio_local_paths, audio_urls

--- a/auto_video_create_server/tests/test_tts_typecast.py
+++ b/auto_video_create_server/tests/test_tts_typecast.py
@@ -1,0 +1,167 @@
+"""Typecast TTS — 단위 테스트 (실제 API 호출 없음, requests mock)."""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import tts_typecast as tc  # noqa: E402
+
+
+def _resp(status=200, content=b"\xff\xfbMP3", body=None):
+    r = mock.Mock()
+    r.status_code = status
+    r.content = content
+    r.json.return_value = body if body is not None else {}
+    r.text = ""
+    return r
+
+
+class TestPayload(unittest.TestCase):
+
+    def _capture(self, **kwargs):
+        with mock.patch.object(tc.requests, "post", return_value=_resp()) as post, \
+             mock.patch("builtins.open", mock.mock_open()):
+            tc.tts_with_typecast("안녕하세요", "/tmp/a.mp3", "KEY", **kwargs)
+        return post.call_args
+
+    def test_endpoint_and_auth_header(self):
+        args = self._capture()
+        self.assertEqual(args[0][0], "https://api.typecast.ai/v1/text-to-speech")
+        self.assertEqual(args.kwargs["headers"]["X-API-KEY"], "KEY")
+
+    def test_default_voice_and_model(self):
+        payload = self._capture().kwargs["json"]
+        self.assertEqual(payload["voice_id"], "tc_62e8f21e979b3860fe2f6a24")
+        self.assertEqual(payload["model"], "ssfm-v30")
+        self.assertEqual(payload["language"], "kor")
+
+    def test_mp3_output_requested(self):
+        payload = self._capture().kwargs["json"]
+        self.assertEqual(payload["output"]["audio_format"], "mp3")
+
+    def test_speed_maps_to_audio_tempo(self):
+        payload = self._capture(speed=1.4).kwargs["json"]
+        self.assertEqual(payload["output"]["audio_tempo"], 1.4)
+
+    def test_voice_id_override(self):
+        payload = self._capture(voice_id="uc_custom").kwargs["json"]
+        self.assertEqual(payload["voice_id"], "uc_custom")
+
+    def test_timeout_is_set(self):
+        """호출이 무한정 붙잡히면 Lambda 30초 예산을 통째로 날린다."""
+        self.assertIsNotNone(self._capture().kwargs.get("timeout"))
+
+
+class TestTempoClamp(unittest.TestCase):
+
+    def test_within_range(self):
+        self.assertEqual(tc._clamp_tempo(1.4), 1.4)
+
+    def test_clamped_to_bounds(self):
+        self.assertEqual(tc._clamp_tempo(5.0), tc.MAX_TEMPO)
+        self.assertEqual(tc._clamp_tempo(0.1), tc.MIN_TEMPO)
+
+    def test_garbage_falls_back_to_1(self):
+        for bad in [None, "빠르게", [], {}]:
+            self.assertEqual(tc._clamp_tempo(bad), 1.0)
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_missing_api_key(self):
+        with self.assertRaises(tc.TypecastError) as cm:
+            tc.tts_with_typecast("안녕", "/tmp/a.mp3", "")
+        self.assertIn("TYPECAST_API_KEY", str(cm.exception))
+
+    def test_empty_text_rejected_before_request(self):
+        """빈 스크립트는 422 를 부르고 장면↔오디오 인덱스를 깨뜨리므로 미리 막는다."""
+        with mock.patch.object(tc.requests, "post") as post:
+            for blank in ["", "   ", None]:
+                with self.assertRaises(tc.TypecastError):
+                    tc.tts_with_typecast(blank, "/tmp/a.mp3", "KEY")
+            post.assert_not_called()
+
+    def test_long_text_truncated(self):
+        long_text = "가" * 3000
+        with mock.patch.object(tc.requests, "post", return_value=_resp()) as post, \
+             mock.patch("builtins.open", mock.mock_open()):
+            tc.tts_with_typecast(long_text, "/tmp/a.mp3", "KEY")
+        self.assertEqual(len(post.call_args.kwargs["json"]["text"]), tc.MAX_TEXT_LENGTH)
+
+
+class TestErrorHandling(unittest.TestCase):
+
+    def test_402_raises_without_retry(self):
+        """결제 오류는 재시도해도 소용없다 (Supertone 사고 때 실제로 겪은 상태)."""
+        resp = _resp(402, body={"message": "Payment Required"})
+        with mock.patch.object(tc.requests, "post", return_value=resp) as post:
+            with self.assertRaises(tc.TypecastError) as cm:
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 1)
+        self.assertIn("402", str(cm.exception))
+
+    def test_429_retries_once(self):
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=[_resp(429), _resp(200)]) as post, \
+             mock.patch.object(tc.time, "sleep"), \
+             mock.patch("builtins.open", mock.mock_open()):
+            path, _ = tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+        self.assertEqual(path, "/tmp/a.mp3")
+
+    def test_retry_gives_up_after_second_failure(self):
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=[_resp(503), _resp(503)]) as post, \
+             mock.patch.object(tc.time, "sleep"):
+            with self.assertRaises(tc.TypecastError):
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+
+    def test_network_error_retried_then_raised(self):
+        import requests as rq
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=rq.RequestException("timeout")) as post, \
+             mock.patch.object(tc.time, "sleep"):
+            with self.assertRaises(tc.TypecastError):
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+
+    def test_api_key_never_in_error_message(self):
+        resp = _resp(401, body={"detail": "invalid key"})
+        with mock.patch.object(tc.requests, "post", return_value=resp):
+            with self.assertRaises(tc.TypecastError) as cm:
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "SUPERSECRETKEY")
+        self.assertNotIn("SUPERSECRETKEY", str(cm.exception))
+
+
+class TestMulti(unittest.TestCase):
+
+    def test_generates_and_uploads_each_script(self):
+        scripts = [{"script": "하나"}, {"script": "둘"}, "셋"]
+        with mock.patch.object(tc, "tts_with_typecast",
+                               side_effect=lambda t, p, *a, **k: (p, None)) as gen, \
+             mock.patch.object(tc, "upload_to_s3",
+                               side_effect=lambda p, b, k: f"https://{b}.s3.amazonaws.com/{k}"), \
+             mock.patch.object(tc.os, "makedirs"):
+            paths, urls = tc.tts_with_typecast_multi(scripts, "KEY")
+        self.assertEqual(len(paths), 3)
+        self.assertEqual(len(urls), 3)
+        self.assertEqual(gen.call_count, 3)
+        # dict / 문자열 스크립트 모두 텍스트로 추출돼야 한다
+        self.assertEqual([c[0][0] for c in gen.call_args_list], ["하나", "둘", "셋"])
+
+    def test_urls_are_unique_per_clip(self):
+        scripts = [{"script": f"s{i}"} for i in range(5)]
+        with mock.patch.object(tc, "tts_with_typecast",
+                               side_effect=lambda t, p, *a, **k: (p, None)), \
+             mock.patch.object(tc, "upload_to_s3",
+                               side_effect=lambda p, b, k: f"https://{b}.s3.amazonaws.com/{k}"), \
+             mock.patch.object(tc.os, "makedirs"):
+            _, urls = tc.tts_with_typecast_multi(scripts, "KEY")
+        self.assertEqual(len(set(urls)), 5, "S3 키가 겹치면 이전 클립을 덮어쓴다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 배경
Supertone 이 `402 Payment Required` 를 반환해 **prod 영상 생성이 전면 중단**된 상태. Typecast 로 교체한다.

## 구현
Typecast 도 **동기식이고 오디오 바이트를 바로 반환**해서 호출부 인터페이스(`tts_with_*_multi`)는 그대로 유지된다 — 교체 범위가 TTS 모듈 1개로 갇힘.

```
POST https://api.typecast.ai/v1/text-to-speech
헤더  X-API-KEY
본문  voice_id / text / model=ssfm-v30 / language=kor
      output.audio_format=mp3, output.audio_tempo=1.4
```

기존 `speed=1.4` → `output.audio_tempo` 로 매핑 (0.5~2.0 범위 clamp).

## 안정성 보강 (이번 사고에서 배운 것)
- **요청 타임아웃 (5,15)초** — 기존 Supertone 호출엔 타임아웃이 아예 없었다. 한 호출이 멈추면 Lambda 30초 예산을 통째로 날린다
- **429/5xx 만 1회 재시도**(1초 백오프). 402/401 은 재시도해도 소용없으므로 즉시 실패
- **빈 스크립트 사전 차단** — Typecast 최소 1자 제약이라 422 가 나고, 장면↔오디오 인덱스가 어긋나 영상이 통째로 깨진다
- **에러 메시지에 API 키 미포함** (응답 본문에서 사유만 추출)
- `generate-video` 에 `TypecastError` 전용 핸들러 → `error_code="tts_failed"` + 사용자에게 보여줄 수 있는 메시지

## ⚠️ 배포 전 필요 — Lambda 환경변수
| 변수 | 값 |
|---|---|
| `TYPECAST_API_KEY` | **(PO가 콘솔에서 직접 등록)** — 필수 |
| `TYPECAST_VOICE_ID` | `tc_62e8f21e979b3860fe2f6a24` (선택, 코드 기본값과 동일) |

키가 없으면 `"TYPECAST_API_KEY 가 설정되지 않았습니다"` 로 명확히 실패한다.

## 남은 이슈 (이 PR 범위 밖)
에러가 나도 **FE 가 `generating` 화면에 멈춰 있어 메시지가 안 보인다**. 이번에 "버튼 눌렀는데 아무 반응 없음"으로 나타난 그 문제. 별도 수정 권장.

`tts_supertone.py` 는 참고용으로 보존(호출부 미사용).

테스트 19개 추가 / 전체 141개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)