### PR TITLE
fix: prod 를 워터마크 없는 Creatomate 템플릿으로 교체

### DIFF
--- a/auto_video_create_server/services/scene_counts.py
+++ b/auto_video_create_server/services/scene_counts.py
@@ -21,8 +21,10 @@ DEFAULT_SCENE_COUNT = 5
 #   template_id_prod / template_id_test: Creatomate 템플릿 ID (ENV 분기)
 #   subtitle_suffixes: 자막 element ID suffix — 반드시 장면 수와 같은 개수여야 한다.
 #                      템플릿마다 다르므로 템플릿과 함께 확보한다.
-# NOTE (2026-08-04, PO 템플릿 제공): 4/6/7/8 템플릿은 prod/test 구분 없이 동일 ID 를 사용한다
-# (PO 가 장면 수당 템플릿 1개씩 제공). 5장면만 기존처럼 prod/test 가 분리돼 있다.
+# NOTE (2026-08-05, PO 제공): prod 는 **워터마크 없는 전용 템플릿**을 쓴다.
+# 전 장면 수(4~8)에 대해 prod/test 템플릿이 서로 다른 ID 로 분리돼 있다.
+# prod 에 test 템플릿이 들어가면 워터마크가 찍힌 영상이 고객에게 나가므로,
+# 아래 두 값을 같은 ID 로 두지 말 것 (test_prod_and_test_templates_differ 로 강제).
 #
 # NOTE (자막 suffix, 2026-08-04 정정): 3번 슬롯 자막은 `Subtitles-MDV` 로 **존재한다**.
 # 최초 등록 시 참고한 Creatomate "API 사용" 예시(curl)에 MDV 가 빠져 있어 없는 줄 알았는데,
@@ -32,28 +34,28 @@ DEFAULT_SCENE_COUNT = 5
 # → 전 장면 수에 MDV 를 포함한다. 슬롯 순서: 1=6K5 2=JTM 3=MDV 4=5Z2 5=D6M 6=3KT 7=6PM 8=3P6
 SCENE_COUNT_CONFIG: dict = {
     4: {
-        "template_id_prod": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
+        "template_id_prod": "6707f308-d77f-49bd-ad5e-d3011b1f4cab",
         "template_id_test": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2"],
     },
     5: {
         # 현행 운영 템플릿 (기존 동작 100% 유지)
-        "template_id_prod": "cab85e50-1e78-41b8-9644-80a061d349f6",
+        "template_id_prod": "8971a2e5-3875-4d2d-9983-eefe9a76b476",
         "template_id_test": "eda9d421-b086-4660-9f3c-9236d826226f",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M"],
     },
     6: {
-        "template_id_prod": "5e530b01-2f3d-428e-b6d6-70a001703550",
+        "template_id_prod": "7ce3586a-1ad1-4d9c-bbb7-a6e229460f9a",
         "template_id_test": "5e530b01-2f3d-428e-b6d6-70a001703550",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT"],
     },
     7: {
-        "template_id_prod": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
+        "template_id_prod": "81cddf37-9e94-4210-99f4-28f4e245d9fb",
         "template_id_test": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM"],
     },
     8: {
-        "template_id_prod": "37229115-682d-41d5-b1f1-20953367b416",
+        "template_id_prod": "5461fe24-1d67-44b4-ba37-f7195db2f79f",
         "template_id_test": "37229115-682d-41d5-b1f1-20953367b416",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM", "3P6"],
     },

--- a/auto_video_create_server/tests/test_scene_counts.py
+++ b/auto_video_create_server/tests/test_scene_counts.py
@@ -53,6 +53,22 @@ class TestTemplateLookup(unittest.TestCase):
         ids = [sc.get_template_id(n) for n in [4, 5, 6, 7, 8]]
         self.assertEqual(len(set(ids)), len(ids), f"중복 템플릿 ID: {ids}")
 
+    def test_prod_and_test_templates_differ(self):
+        """prod 는 워터마크 없는 전용 템플릿을 써야 한다 (2026-08-05).
+
+        prod 에 test 템플릿 ID 가 들어가면 워터마크가 찍힌 영상이 고객에게 나간다.
+        """
+        for n, config in sc.SCENE_COUNT_CONFIG.items():
+            prod, test = config.get("template_id_prod"), config.get("template_id_test")
+            self.assertTrue(prod, f"{n}장면 prod 템플릿 미등록")
+            self.assertTrue(test, f"{n}장면 test 템플릿 미등록")
+            self.assertNotEqual(prod, test, f"{n}장면 prod/test 템플릿이 동일 — 워터마크 위험")
+
+    def test_prod_template_ids_unique(self):
+        """prod 템플릿끼리도 중복이 없어야 한다 (붙여넣기 실수 방지)."""
+        prod_ids = [c["template_id_prod"] for c in sc.SCENE_COUNT_CONFIG.values()]
+        self.assertEqual(len(set(prod_ids)), len(prod_ids), f"prod 템플릿 중복: {prod_ids}")
+
     def test_env_switches_template_id(self):
         with mock.patch.dict(os.environ, {"ENV": "production"}):
             prod_id = sc.get_template_id(5)


### PR DESCRIPTION
## 변경
prod 영상에 워터마크가 찍히면 안 되므로, 장면 수 4~8 전부 **prod 전용 템플릿**으로 교체한다. test 템플릿은 그대로 유지 (ENV 로 분기).

| 장면 | prod (워터마크 없음) | test |
|---|---|---|
| 4 | `6707f308` | `0e8036d2` |
| 5 | `8971a2e5` | `eda9d421` |
| 6 | `7ce3586a` | `5e530b01` |
| 7 | `81cddf37` | `ffcddeb1` |
| 8 | `5461fe24` | `37229115` |

5장면 prod 도 기존 `cab85e50` → `8971a2e5` 로 교체된다.

## 회귀 테스트 2개
- **prod/test 템플릿이 같으면 실패** — 워터마크 찍힌 영상이 고객에게 나가는 사고를 CI 에서 차단
- prod 템플릿끼리 중복 금지 (붙여넣기 실수 방지)

## ⚠️ 배포 후 확인 필요
자막 element suffix(`Subtitles-6K5` 등)는 **prod/test 공용 설정**이다. 새 prod 템플릿을 test 템플릿에서 복제한 것이라면 이름이 같아 문제없지만, 별도로 만든 것이라면 **prod 에서 자막 스타일이 안 먹을 수 있다.** 배포 후 prod 영상 1건으로 자막 폰트/색이 반영되는지 확인 권장.

테스트 143개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)