### PR TITLE
Release — Typecast TTS 전환 + 에러 안내 + prod 워터마크 없는 템플릿 (main → prod)

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -56,6 +56,12 @@ function parseSuggestedSections(raw: unknown, expectedLength: number): Suggested
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
+// 영상 생성이 실패했을 때 사용자가 다음에 뭘 해야 할지 알려준다.
+// (외부 서비스 장애·결제 문제 등은 사용자가 스스로 해결할 수 없으므로 관리자 문의로 안내)
+const ADMIN_CONTACT_GUIDE = "잠시 후 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요.";
+const withContactGuide = (message?: string | null) =>
+  `${(message || "").trim() || "영상 생성에 실패했어요."} ${ADMIN_CONTACT_GUIDE}`;
+
 const getProxiedImageUrl = (url: string) => `/api/image-proxy?url=${encodeURIComponent(url)}`;
 
 // 공통 fetch wrapper 함수 추가
@@ -338,7 +344,7 @@ export default function Home() {
         setError(data.message || "이미지/영상/스크립트 추출에 실패했습니다.");
       }
     } catch {
-      setError("서버 요청 중 오류가 발생했습니다.");
+      setError(withContactGuide("서버 요청 중 오류가 생겼어요."));
     } finally {
       setLoading(false);
     }
@@ -380,7 +386,7 @@ export default function Home() {
             videoUrl = pollData.url;
             break;
           } else if (pollData.status === "failed") {
-            setGenerateError("영상 생성에 실패했습니다.");
+            setGenerateError(withContactGuide("영상 합성 중 문제가 생겼어요."));
             setStep('select');
             return;
           }
@@ -391,15 +397,17 @@ export default function Home() {
           setVideoUrl(videoUrl);
           setStep('done');
         } else {
-          setGenerateError("영상 생성이 제한 시간 내에 완료되지 않았습니다.");
+          setGenerateError(withContactGuide("영상 생성이 제한 시간 내에 끝나지 않았어요."));
           setStep('select');
         }
       } else {
-        setGenerateError(data.message || "영상 생성에 실패했습니다.");
+        // BE 가 내려준 사유(예: 음성 생성 실패, 템플릿 미설정)를 그대로 보여주고
+        // 사용자가 할 수 있는 다음 행동을 덧붙인다.
+        setGenerateError(withContactGuide(data.message));
         setStep('select');
       }
     } catch {
-      setGenerateError("서버 요청 중 오류가 발생했습니다.");
+      setGenerateError(withContactGuide("서버 요청 중 오류가 생겼어요."));
       setStep('select');
     }
   };
@@ -606,6 +614,16 @@ export default function Home() {
                     </Button>
                   </Box>
                 </Box>
+                {/* 영상 생성 실패 안내 (PC).
+                    기존에는 이 배너가 모바일 분기에만 있어, PC 에서는 실패해도
+                    아무 설명 없이 select 화면으로 돌아와 "반응 없음"처럼 보였다. */}
+                {generateError && (
+                  <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
+                    <Alert severity="error" onClose={() => setGenerateError(null)}>
+                      {generateError}
+                    </Alert>
+                  </Box>
+                )}
                 {/* cycle-3: 자막 스타일 설정 (Row 1 — 접힘 기본) */}
                 <Box sx={{ width: '100%', maxWidth: 1200, mx: 'auto', px: 4, mt: 2 }}>
                   <SubtitleStyleEditor onSettingsChange={setSubtitleSettings} />
@@ -1039,7 +1057,11 @@ export default function Home() {
                 >
                   최종 영상 생성하기
                 </Button>
-                {generateError && <Typography color="error" sx={{ mb: 2 }}>{generateError}</Typography>}
+                {generateError && (
+                  <Alert severity="error" sx={{ mb: 2 }} onClose={() => setGenerateError(null)}>
+                    {generateError}
+                  </Alert>
+                )}
               </Box>
             )
           )}

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -3,7 +3,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from services.blog_shorts import extract_blog_content, get_blog_media_and_scripts
 from services.summarize import summarize_for_shorts_sets
-from services.tts_supertone import tts_with_supertone_multi
+from services.tts_typecast import (
+    tts_with_typecast_multi,
+    TypecastError,
+    DEFAULT_VOICE_ID as DEFAULT_TYPECAST_VOICE_ID,
+)
 from services.create_creatomate_video import create_creatomate_video, get_creatomate_vars, poll_creatomate_video_url
 from services.account_service import get_user_if_active, check_user_credits, get_current_credits
 from services.ai_background import generate_backgrounds_parallel, FALLBACK_URL as DEFAULT_BG_FALLBACK_URL
@@ -283,15 +287,15 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
             req.scene_count if req.scene_count is not None else len(req.scripts)
         )
 
-        # 1. TTS 변환 (scripts → mp3 url)
-        SUPERTONE_API_KEY = os.environ.get("SUPERTONE_API_KEY")
-        SUPERTONE_VOICE_ID = "c9220df3a5a70647d7b022"
-        SUPERTONE_SPEED = 1.4
-        audio_local_paths, audio_urls = tts_with_supertone_multi(
+        # 1. TTS 변환 (scripts → mp3 url) — 2026-08-05 Supertone → Typecast 전환
+        TYPECAST_API_KEY = os.environ.get("TYPECAST_API_KEY")
+        TYPECAST_VOICE_ID = os.environ.get("TYPECAST_VOICE_ID", DEFAULT_TYPECAST_VOICE_ID)
+        TTS_SPEED = 1.4
+        audio_local_paths, audio_urls = tts_with_typecast_multi(
             req.scripts,
-            api_key=SUPERTONE_API_KEY,
-            voice_id=SUPERTONE_VOICE_ID,
-            speed=SUPERTONE_SPEED
+            api_key=TYPECAST_API_KEY,
+            voice_id=TYPECAST_VOICE_ID,
+            speed=TTS_SPEED,
         )
         audio_local_paths = audio_local_paths[:scene_count]
         audio_urls = audio_urls[:scene_count]
@@ -375,6 +379,16 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
 
         poll_url = f"https://api.creatomate.com/v1/renders/{render_id}"
         return {"status": "started", "render_id": render_id, "poll_url": poll_url}
+    except TypecastError as e:
+        # 음성 생성 실패 — 사용자에게 보여줄 수 있는 메시지를 그대로 전달.
+        # (API 키 잔액 소진/한도 초과 등이 여기로 온다)
+        print("[generate_video] TTS 실패:", e)
+        return {
+            "status": "error",
+            "error_code": "tts_failed",
+            "message": f"음성을 만들지 못했어요. {e}",
+            "error_type": "tts_failed",
+        }
     except Exception as e:
         print("[generate_video 에러]", e)
         return {"status": "error", "message": str(e)}

--- a/auto_video_create_server/services/scene_counts.py
+++ b/auto_video_create_server/services/scene_counts.py
@@ -21,8 +21,10 @@ DEFAULT_SCENE_COUNT = 5
 #   template_id_prod / template_id_test: Creatomate 템플릿 ID (ENV 분기)
 #   subtitle_suffixes: 자막 element ID suffix — 반드시 장면 수와 같은 개수여야 한다.
 #                      템플릿마다 다르므로 템플릿과 함께 확보한다.
-# NOTE (2026-08-04, PO 템플릿 제공): 4/6/7/8 템플릿은 prod/test 구분 없이 동일 ID 를 사용한다
-# (PO 가 장면 수당 템플릿 1개씩 제공). 5장면만 기존처럼 prod/test 가 분리돼 있다.
+# NOTE (2026-08-05, PO 제공): prod 는 **워터마크 없는 전용 템플릿**을 쓴다.
+# 전 장면 수(4~8)에 대해 prod/test 템플릿이 서로 다른 ID 로 분리돼 있다.
+# prod 에 test 템플릿이 들어가면 워터마크가 찍힌 영상이 고객에게 나가므로,
+# 아래 두 값을 같은 ID 로 두지 말 것 (test_prod_and_test_templates_differ 로 강제).
 #
 # NOTE (자막 suffix, 2026-08-04 정정): 3번 슬롯 자막은 `Subtitles-MDV` 로 **존재한다**.
 # 최초 등록 시 참고한 Creatomate "API 사용" 예시(curl)에 MDV 가 빠져 있어 없는 줄 알았는데,
@@ -32,28 +34,28 @@ DEFAULT_SCENE_COUNT = 5
 # → 전 장면 수에 MDV 를 포함한다. 슬롯 순서: 1=6K5 2=JTM 3=MDV 4=5Z2 5=D6M 6=3KT 7=6PM 8=3P6
 SCENE_COUNT_CONFIG: dict = {
     4: {
-        "template_id_prod": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
+        "template_id_prod": "6707f308-d77f-49bd-ad5e-d3011b1f4cab",
         "template_id_test": "0e8036d2-04d3-436c-8c02-7b8708a85f06",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2"],
     },
     5: {
         # 현행 운영 템플릿 (기존 동작 100% 유지)
-        "template_id_prod": "cab85e50-1e78-41b8-9644-80a061d349f6",
+        "template_id_prod": "8971a2e5-3875-4d2d-9983-eefe9a76b476",
         "template_id_test": "eda9d421-b086-4660-9f3c-9236d826226f",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M"],
     },
     6: {
-        "template_id_prod": "5e530b01-2f3d-428e-b6d6-70a001703550",
+        "template_id_prod": "7ce3586a-1ad1-4d9c-bbb7-a6e229460f9a",
         "template_id_test": "5e530b01-2f3d-428e-b6d6-70a001703550",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT"],
     },
     7: {
-        "template_id_prod": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
+        "template_id_prod": "81cddf37-9e94-4210-99f4-28f4e245d9fb",
         "template_id_test": "ffcddeb1-55da-4276-8998-b67fc2f92a82",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM"],
     },
     8: {
-        "template_id_prod": "37229115-682d-41d5-b1f1-20953367b416",
+        "template_id_prod": "5461fe24-1d67-44b4-ba37-f7195db2f79f",
         "template_id_test": "37229115-682d-41d5-b1f1-20953367b416",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M", "3KT", "6PM", "3P6"],
     },

--- a/auto_video_create_server/services/tts_typecast.py
+++ b/auto_video_create_server/services/tts_typecast.py
@@ -1,0 +1,139 @@
+"""Typecast TTS — Supertone 대체 (2026-08-05).
+
+Typecast API 는 Supertone 과 마찬가지로 **동기식**이며 오디오 바이트를 바로 반환하므로
+호출부 인터페이스(tts_with_*_multi)를 그대로 유지한다.
+
+API 요약 (https://typecast.ai/docs/ko/api-reference/text-to-speech/text-to-speech):
+    POST https://api.typecast.ai/v1/text-to-speech
+    헤더: X-API-KEY
+    본문: voice_id(tc_/uc_ 접두), text(1~2000자), model(ssfm-v30|ssfm-v21),
+          output.audio_format(wav|mp3), output.audio_tempo(0.5~2.0)
+    응답: 원본 오디오 바이트 (mp3 요청 시 audio/mpeg)
+"""
+import os
+import time
+
+import boto3
+import requests
+
+TYPECAST_URL = "https://api.typecast.ai/v1/text-to-speech"
+DEFAULT_MODEL = "ssfm-v30"
+DEFAULT_VOICE_ID = "tc_62e8f21e979b3860fe2f6a24"
+
+# Typecast text 제약: 1~2000자
+MAX_TEXT_LENGTH = 2000
+# audio_tempo 허용 범위
+MIN_TEMPO, MAX_TEMPO = 0.5, 2.0
+
+# Lambda 전체 예산이 30초라 한 호출이 오래 붙잡히면 안 된다. (연결, 응답) 초.
+REQUEST_TIMEOUT = (5, 15)
+# 일시적 오류(429/5xx)만 1회 재시도 — 예산을 크게 넘기지 않는 선에서.
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+RETRY_BACKOFF_SEC = 1.0
+
+S3_BUCKET = "auto-video-tts-files"
+
+
+class TypecastError(Exception):
+    """Typecast TTS 실패. 메시지는 사용자에게 노출될 수 있으므로 키를 담지 않는다."""
+
+
+def upload_to_s3(local_path, bucket, s3_key):
+    s3 = boto3.client("s3")
+    s3.upload_file(local_path, bucket, s3_key)
+    return f"https://{bucket}.s3.amazonaws.com/{s3_key}"
+
+
+def _clamp_tempo(speed):
+    try:
+        tempo = float(speed)
+    except (TypeError, ValueError):
+        return 1.0
+    return max(MIN_TEMPO, min(MAX_TEMPO, tempo))
+
+
+def tts_with_typecast(text, output_path, api_key, voice_id=None, speed=1.4,
+                      model=DEFAULT_MODEL, language="kor"):
+    """텍스트 1건 → mp3 파일. 성공 시 (output_path, None) 반환."""
+    if not api_key:
+        raise TypecastError("TYPECAST_API_KEY 가 설정되지 않았습니다.")
+
+    text = (text or "").strip()
+    if not text:
+        # 빈 스크립트는 Typecast 가 422 로 거절한다(최소 1자). 장면↔오디오 인덱스가
+        # 어긋나면 영상이 통째로 망가지므로, 조용히 넘기지 않고 명확히 실패시킨다.
+        raise TypecastError("스크립트가 비어 있어 음성을 만들 수 없어요. 해당 스크립트를 채워주세요.")
+    if len(text) > MAX_TEXT_LENGTH:
+        text = text[:MAX_TEXT_LENGTH]
+
+    payload = {
+        "voice_id": voice_id or DEFAULT_VOICE_ID,
+        "text": text,
+        "model": model,
+        "language": language,
+        "output": {
+            "audio_format": "mp3",
+            "audio_tempo": _clamp_tempo(speed),
+        },
+    }
+    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+
+    last_error = None
+    for attempt in range(2):  # 최초 1회 + 재시도 1회
+        try:
+            response = requests.post(
+                TYPECAST_URL, headers=headers, json=payload, timeout=REQUEST_TIMEOUT
+            )
+        except requests.RequestException as e:
+            last_error = f"Typecast 요청 실패: {e}"
+            if attempt == 0:
+                time.sleep(RETRY_BACKOFF_SEC)
+                continue
+            raise TypecastError(last_error)
+
+        if response.status_code == 200:
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+            return output_path, None
+
+        # 실패 — 본문에서 사유만 뽑아 로그/에러에 남긴다 (키는 절대 남기지 않음)
+        detail = ""
+        try:
+            body = response.json()
+            detail = body.get("detail") or body.get("message") or body.get("error_code") or ""
+        except Exception:
+            detail = (response.text or "")[:200]
+        last_error = f"Typecast {response.status_code}: {detail}".strip()
+        print(f"[tts_typecast] {last_error}")
+
+        if response.status_code in RETRY_STATUSES and attempt == 0:
+            time.sleep(RETRY_BACKOFF_SEC)
+            continue
+        raise TypecastError(last_error)
+
+    raise TypecastError(last_error or "Typecast 호출 실패")
+
+
+def tts_with_typecast_multi(scripts, api_key, voice_id=None, speed=1.4,
+                            output_dir="/tmp/tts_outputs"):
+    """스크립트 N개 → mp3 N개 생성 후 S3 업로드.
+
+    반환: (로컬 경로 리스트, S3 URL 리스트) — 기존 Supertone 함수와 동일 시그니처.
+    """
+    print(f"tts_with_typecast_multi 호출 (scripts={len(scripts)})")
+    os.makedirs(output_dir, exist_ok=True)
+    audio_local_paths = []
+    audio_urls = []
+
+    for idx, item in enumerate(scripts, 1):
+        text = item["script"] if isinstance(item, dict) else item
+        output_path = os.path.join(output_dir, f"shorts_script_{idx}.mp3")
+        local_path, _ = tts_with_typecast(
+            text, output_path, api_key, voice_id=voice_id, speed=speed
+        )
+        audio_local_paths.append(local_path)
+        ms = int(time.time() * 1000)
+        s3_key = f"shorts_script_{idx}_{ms}.mp3"
+        audio_urls.append(upload_to_s3(local_path, S3_BUCKET, s3_key))
+
+    return audio_local_paths, audio_urls

--- a/auto_video_create_server/tests/test_scene_counts.py
+++ b/auto_video_create_server/tests/test_scene_counts.py
@@ -53,6 +53,22 @@ class TestTemplateLookup(unittest.TestCase):
         ids = [sc.get_template_id(n) for n in [4, 5, 6, 7, 8]]
         self.assertEqual(len(set(ids)), len(ids), f"중복 템플릿 ID: {ids}")
 
+    def test_prod_and_test_templates_differ(self):
+        """prod 는 워터마크 없는 전용 템플릿을 써야 한다 (2026-08-05).
+
+        prod 에 test 템플릿 ID 가 들어가면 워터마크가 찍힌 영상이 고객에게 나간다.
+        """
+        for n, config in sc.SCENE_COUNT_CONFIG.items():
+            prod, test = config.get("template_id_prod"), config.get("template_id_test")
+            self.assertTrue(prod, f"{n}장면 prod 템플릿 미등록")
+            self.assertTrue(test, f"{n}장면 test 템플릿 미등록")
+            self.assertNotEqual(prod, test, f"{n}장면 prod/test 템플릿이 동일 — 워터마크 위험")
+
+    def test_prod_template_ids_unique(self):
+        """prod 템플릿끼리도 중복이 없어야 한다 (붙여넣기 실수 방지)."""
+        prod_ids = [c["template_id_prod"] for c in sc.SCENE_COUNT_CONFIG.values()]
+        self.assertEqual(len(set(prod_ids)), len(prod_ids), f"prod 템플릿 중복: {prod_ids}")
+
     def test_env_switches_template_id(self):
         with mock.patch.dict(os.environ, {"ENV": "production"}):
             prod_id = sc.get_template_id(5)

--- a/auto_video_create_server/tests/test_tts_typecast.py
+++ b/auto_video_create_server/tests/test_tts_typecast.py
@@ -1,0 +1,167 @@
+"""Typecast TTS — 단위 테스트 (실제 API 호출 없음, requests mock)."""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import tts_typecast as tc  # noqa: E402
+
+
+def _resp(status=200, content=b"\xff\xfbMP3", body=None):
+    r = mock.Mock()
+    r.status_code = status
+    r.content = content
+    r.json.return_value = body if body is not None else {}
+    r.text = ""
+    return r
+
+
+class TestPayload(unittest.TestCase):
+
+    def _capture(self, **kwargs):
+        with mock.patch.object(tc.requests, "post", return_value=_resp()) as post, \
+             mock.patch("builtins.open", mock.mock_open()):
+            tc.tts_with_typecast("안녕하세요", "/tmp/a.mp3", "KEY", **kwargs)
+        return post.call_args
+
+    def test_endpoint_and_auth_header(self):
+        args = self._capture()
+        self.assertEqual(args[0][0], "https://api.typecast.ai/v1/text-to-speech")
+        self.assertEqual(args.kwargs["headers"]["X-API-KEY"], "KEY")
+
+    def test_default_voice_and_model(self):
+        payload = self._capture().kwargs["json"]
+        self.assertEqual(payload["voice_id"], "tc_62e8f21e979b3860fe2f6a24")
+        self.assertEqual(payload["model"], "ssfm-v30")
+        self.assertEqual(payload["language"], "kor")
+
+    def test_mp3_output_requested(self):
+        payload = self._capture().kwargs["json"]
+        self.assertEqual(payload["output"]["audio_format"], "mp3")
+
+    def test_speed_maps_to_audio_tempo(self):
+        payload = self._capture(speed=1.4).kwargs["json"]
+        self.assertEqual(payload["output"]["audio_tempo"], 1.4)
+
+    def test_voice_id_override(self):
+        payload = self._capture(voice_id="uc_custom").kwargs["json"]
+        self.assertEqual(payload["voice_id"], "uc_custom")
+
+    def test_timeout_is_set(self):
+        """호출이 무한정 붙잡히면 Lambda 30초 예산을 통째로 날린다."""
+        self.assertIsNotNone(self._capture().kwargs.get("timeout"))
+
+
+class TestTempoClamp(unittest.TestCase):
+
+    def test_within_range(self):
+        self.assertEqual(tc._clamp_tempo(1.4), 1.4)
+
+    def test_clamped_to_bounds(self):
+        self.assertEqual(tc._clamp_tempo(5.0), tc.MAX_TEMPO)
+        self.assertEqual(tc._clamp_tempo(0.1), tc.MIN_TEMPO)
+
+    def test_garbage_falls_back_to_1(self):
+        for bad in [None, "빠르게", [], {}]:
+            self.assertEqual(tc._clamp_tempo(bad), 1.0)
+
+
+class TestValidation(unittest.TestCase):
+
+    def test_missing_api_key(self):
+        with self.assertRaises(tc.TypecastError) as cm:
+            tc.tts_with_typecast("안녕", "/tmp/a.mp3", "")
+        self.assertIn("TYPECAST_API_KEY", str(cm.exception))
+
+    def test_empty_text_rejected_before_request(self):
+        """빈 스크립트는 422 를 부르고 장면↔오디오 인덱스를 깨뜨리므로 미리 막는다."""
+        with mock.patch.object(tc.requests, "post") as post:
+            for blank in ["", "   ", None]:
+                with self.assertRaises(tc.TypecastError):
+                    tc.tts_with_typecast(blank, "/tmp/a.mp3", "KEY")
+            post.assert_not_called()
+
+    def test_long_text_truncated(self):
+        long_text = "가" * 3000
+        with mock.patch.object(tc.requests, "post", return_value=_resp()) as post, \
+             mock.patch("builtins.open", mock.mock_open()):
+            tc.tts_with_typecast(long_text, "/tmp/a.mp3", "KEY")
+        self.assertEqual(len(post.call_args.kwargs["json"]["text"]), tc.MAX_TEXT_LENGTH)
+
+
+class TestErrorHandling(unittest.TestCase):
+
+    def test_402_raises_without_retry(self):
+        """결제 오류는 재시도해도 소용없다 (Supertone 사고 때 실제로 겪은 상태)."""
+        resp = _resp(402, body={"message": "Payment Required"})
+        with mock.patch.object(tc.requests, "post", return_value=resp) as post:
+            with self.assertRaises(tc.TypecastError) as cm:
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 1)
+        self.assertIn("402", str(cm.exception))
+
+    def test_429_retries_once(self):
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=[_resp(429), _resp(200)]) as post, \
+             mock.patch.object(tc.time, "sleep"), \
+             mock.patch("builtins.open", mock.mock_open()):
+            path, _ = tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+        self.assertEqual(path, "/tmp/a.mp3")
+
+    def test_retry_gives_up_after_second_failure(self):
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=[_resp(503), _resp(503)]) as post, \
+             mock.patch.object(tc.time, "sleep"):
+            with self.assertRaises(tc.TypecastError):
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+
+    def test_network_error_retried_then_raised(self):
+        import requests as rq
+        with mock.patch.object(tc.requests, "post",
+                               side_effect=rq.RequestException("timeout")) as post, \
+             mock.patch.object(tc.time, "sleep"):
+            with self.assertRaises(tc.TypecastError):
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY")
+        self.assertEqual(post.call_count, 2)
+
+    def test_api_key_never_in_error_message(self):
+        resp = _resp(401, body={"detail": "invalid key"})
+        with mock.patch.object(tc.requests, "post", return_value=resp):
+            with self.assertRaises(tc.TypecastError) as cm:
+                tc.tts_with_typecast("안녕", "/tmp/a.mp3", "SUPERSECRETKEY")
+        self.assertNotIn("SUPERSECRETKEY", str(cm.exception))
+
+
+class TestMulti(unittest.TestCase):
+
+    def test_generates_and_uploads_each_script(self):
+        scripts = [{"script": "하나"}, {"script": "둘"}, "셋"]
+        with mock.patch.object(tc, "tts_with_typecast",
+                               side_effect=lambda t, p, *a, **k: (p, None)) as gen, \
+             mock.patch.object(tc, "upload_to_s3",
+                               side_effect=lambda p, b, k: f"https://{b}.s3.amazonaws.com/{k}"), \
+             mock.patch.object(tc.os, "makedirs"):
+            paths, urls = tc.tts_with_typecast_multi(scripts, "KEY")
+        self.assertEqual(len(paths), 3)
+        self.assertEqual(len(urls), 3)
+        self.assertEqual(gen.call_count, 3)
+        # dict / 문자열 스크립트 모두 텍스트로 추출돼야 한다
+        self.assertEqual([c[0][0] for c in gen.call_args_list], ["하나", "둘", "셋"])
+
+    def test_urls_are_unique_per_clip(self):
+        scripts = [{"script": f"s{i}"} for i in range(5)]
+        with mock.patch.object(tc, "tts_with_typecast",
+                               side_effect=lambda t, p, *a, **k: (p, None)), \
+             mock.patch.object(tc, "upload_to_s3",
+                               side_effect=lambda p, b, k: f"https://{b}.s3.amazonaws.com/{k}"), \
+             mock.patch.object(tc.os, "makedirs"):
+            _, urls = tc.tts_with_typecast_multi(scripts, "KEY")
+        self.assertEqual(len(set(urls)), 5, "S3 키가 겹치면 이전 클립을 덮어쓴다")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🚨 긴급 복구 릴리즈
Supertone 이 `402 Payment Required` 를 반환해 **prod 영상 생성이 전면 중단**된 상태를 복구한다.

## 릴리즈 범위

### 1. TTS Supertone → Typecast 전환 (#63)
- `services/tts_typecast.py` 신설. 동기식·오디오 바이트 직접 반환이라 호출부 인터페이스 유지
- `speed=1.4` → `output.audio_tempo`, mp3 출력, `model=ssfm-v30`, `language=kor`
- **안정성 보강**: 요청 타임아웃(기존엔 없었음) / 429·5xx 만 1회 재시도 / 402·401 즉시 실패 / 빈 스크립트 사전 차단 / 에러 메시지에 API 키 미포함

### 2. 영상 생성 실패 안내 (#63)
- **PC 에 에러 배너 신설** — 기존엔 모바일 분기에만 있어 PC 에서 실패 시 아무 설명 없이 select 로 돌아와 "반응 없음"처럼 보였다 (이번 장애가 이 형태로 나타남)
- 모든 실패 경로에 관리자 문의 안내: BE 사유 + "잠시 후 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요."

### 3. prod 워터마크 없는 Creatomate 템플릿 (#64)
- 장면 수 4~8 전부 prod 전용 템플릿으로 교체 (test 는 유지, ENV 분기)
- prod/test 템플릿이 같으면 CI 가 실패하도록 회귀 테스트 추가

## ⚠️ 배포 전 필수
**prod Lambda 환경변수 `TYPECAST_API_KEY`** 가 등록돼 있어야 한다. 없으면 `"TYPECAST_API_KEY 가 설정되지 않았습니다"` 로 실패한다.

## 배포 후 확인
1. prod 에서 영상 1건 생성 → 음성이 나오는지 (Typecast 정상 동작)
2. **워터마크가 없는지**
3. 자막 폰트/색이 반영되는지 — 새 prod 템플릿의 자막 element 이름이 test 와 같은지 검증 필요

테스트 143개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)