### PR TITLE
Release — Creatomate 에러 로깅 + 에러 문구 단순화 (main → prod)

### DIFF
--- a/auto_video_create_front/src/app/page.tsx
+++ b/auto_video_create_front/src/app/page.tsx
@@ -56,11 +56,11 @@ function parseSuggestedSections(raw: unknown, expectedLength: number): Suggested
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "";
 
-// 영상 생성이 실패했을 때 사용자가 다음에 뭘 해야 할지 알려준다.
-// (외부 서비스 장애·결제 문제 등은 사용자가 스스로 해결할 수 없으므로 관리자 문의로 안내)
-const ADMIN_CONTACT_GUIDE = "잠시 후 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요.";
-const withContactGuide = (message?: string | null) =>
-  `${(message || "").trim() || "영상 생성에 실패했어요."} ${ADMIN_CONTACT_GUIDE}`;
+// 영상 생성 실패 안내.
+// 실패 원인(외부 API 상태 코드, 템플릿 문제 등)은 사용자가 어차피 손쓸 수 없고
+// 서버 로그에 상세히 남으므로, 화면에는 다음 행동만 간결하게 안내한다.
+const GENERATE_ERROR_MESSAGE =
+  "영상 생성에 실패했어요. 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요.";
 
 const getProxiedImageUrl = (url: string) => `/api/image-proxy?url=${encodeURIComponent(url)}`;
 
@@ -344,7 +344,7 @@ export default function Home() {
         setError(data.message || "이미지/영상/스크립트 추출에 실패했습니다.");
       }
     } catch {
-      setError(withContactGuide("서버 요청 중 오류가 생겼어요."));
+      setError("요청 중 오류가 생겼어요. 다시 시도해보시고, 계속 안 되면 관리자에게 문의해주세요.");
     } finally {
       setLoading(false);
     }
@@ -386,7 +386,7 @@ export default function Home() {
             videoUrl = pollData.url;
             break;
           } else if (pollData.status === "failed") {
-            setGenerateError(withContactGuide("영상 합성 중 문제가 생겼어요."));
+            setGenerateError(GENERATE_ERROR_MESSAGE);
             setStep('select');
             return;
           }
@@ -397,17 +397,17 @@ export default function Home() {
           setVideoUrl(videoUrl);
           setStep('done');
         } else {
-          setGenerateError(withContactGuide("영상 생성이 제한 시간 내에 끝나지 않았어요."));
+          setGenerateError(GENERATE_ERROR_MESSAGE);
           setStep('select');
         }
       } else {
         // BE 가 내려준 사유(예: 음성 생성 실패, 템플릿 미설정)를 그대로 보여주고
         // 사용자가 할 수 있는 다음 행동을 덧붙인다.
-        setGenerateError(withContactGuide(data.message));
+        setGenerateError(GENERATE_ERROR_MESSAGE);
         setStep('select');
       }
     } catch {
-      setGenerateError(withContactGuide("서버 요청 중 오류가 생겼어요."));
+      setGenerateError(GENERATE_ERROR_MESSAGE);
       setStep('select');
     }
   };

--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -375,7 +375,14 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
         if isinstance(result, dict):
             render_id = result.get('id')
         if not render_id:
-            return {"status": "error", "message": "Creatomate 응답에 렌더링 ID가 없습니다."}
+            # 어떤 응답이 왔는지 남긴다 — 이게 없어서 원인 파악이 불가능했다 (2026-08-06)
+            print(f"[generate_video] Creatomate 응답에 render_id 없음: {str(result)[:500]}")
+            return {
+                "status": "error",
+                "error_code": "creatomate_no_render_id",
+                "message": "Creatomate 응답에 렌더링 ID가 없습니다.",
+                "error_type": "creatomate_no_render_id",
+            }
 
         poll_url = f"https://api.creatomate.com/v1/renders/{render_id}"
         return {"status": "started", "render_id": render_id, "poll_url": poll_url}

--- a/auto_video_create_server/services/create_creatomate_video.py
+++ b/auto_video_create_server/services/create_creatomate_video.py
@@ -63,11 +63,42 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
                 "Authorization": f"Bearer {CREATOMATE_API_KEY}",
                 "Content-Type": "application/json"
             },
-            data=json.dumps(payload)
+            data=json.dumps(payload),
+            # 타임아웃이 없으면 Creatomate 가 응답을 안 줄 때 Lambda 30초 예산을 통째로 날린다.
+            timeout=(5, 20),
         )
-        
-        result = response.json()
-        
+
+        try:
+            result = response.json()
+        except ValueError:
+            result = None
+
+        # 진단 로그: 상태 코드 + 응답 본문 요약.
+        # 이게 없어서 "렌더링 ID가 없습니다" 만 뜨고 원인을 알 수 없었다 (2026-08-06).
+        # Authorization 헤더는 절대 로그에 남기지 않는다.
+        print(
+            f"[create_creatomate_video] template_id={template_id} "
+            f"status={response.status_code} body={str(result)[:500] if result is not None else (response.text or '')[:500]}"
+        )
+
+        if response.status_code >= 400:
+            # Creatomate 는 에러를 message/hint 등 다양한 키로 준다 — 있는 대로 뽑아 올린다.
+            detail = ""
+            if isinstance(result, dict):
+                detail = (
+                    result.get("message")
+                    or result.get("hint")
+                    or result.get("error")
+                    or ""
+                )
+            if not detail:
+                detail = (response.text or "")[:200]
+            print(f"[create_creatomate_video] 실패 status={response.status_code} detail={detail}")
+            return {
+                "error": "creatomate_error",
+                "message": f"Creatomate {response.status_code}: {detail}".strip(),
+            }
+
         # 성공 시 크레딧 차감
         if user_id and response.status_code == 200:
             # render_id가 있는지 확인 (성공적인 렌더링 시작)


### PR DESCRIPTION
prod 에서 "Creatomate 응답에 렌더링 ID가 없습니다" 의 **원인을 특정하기 위한 진단 로깅**을 넣는다.

- Creatomate 응답 status + body 를 template_id 와 함께 로깅 (기존엔 전부 버려서 원인 파악 불가)
- 4xx/5xx 사유 추출 후 구조화된 에러 반환 + 요청 타임아웃 추가
- FE 에러 문구를 "다시 시도 / 관리자 문의" 로 단순화 (내부 사유 비노출)

배포 후 prod 1회 재시도 → 로그에서 실제 실패 사유 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)