### PR TITLE
feat(monitoring): 장애 알림용 [ALERT] 마커 도입

### DIFF
--- a/auto_video_create_server/api/blog.py
+++ b/auto_video_create_server/api/blog.py
@@ -12,6 +12,7 @@ from services.create_creatomate_video import create_creatomate_video, get_creato
 from services.account_service import get_user_if_active, check_user_credits, get_current_credits
 from services.ai_background import generate_backgrounds_parallel, FALLBACK_URL as DEFAULT_BG_FALLBACK_URL
 from services.image_mirror import maybe_mirror
+from services.alerting import alert
 # cycle-3: 자막 스타일 편집 신규 서비스
 from services.font_service import get_korean_fonts, get_allowed_font_families
 from services.subtitle_settings_service import (
@@ -48,6 +49,19 @@ from urllib.parse import urlparse
 # from services.tts_fal import ...
 # from services.create_creatomate_video import ...
 # from services.extract_blog import ...
+
+
+def _safe_host(url) -> str:
+    """알림에 남길 블로그 호스트만 뽑는다.
+
+    URL 전체를 남기면 유저가 어떤 글을 봤는지가 로그에 쌓인다. 진단에 필요한 건
+    "어느 플랫폼 파서가 깨졌나"뿐이므로 호스트만 남긴다.
+    """
+    try:
+        return urlparse(str(url)).netloc or "(unknown)"
+    except Exception:
+        return "(unparsable)"
+
 
 def require_active_subscription(request: Request):
     user_id = request.headers.get("X-USER-ID") or request.query_params.get("id")
@@ -220,8 +234,21 @@ def extract_all(req: ExtractMediaRequest, user=Depends(require_active_subscripti
             "message": "지원하지 않는 블로그 플랫폼이에요. 네이버 블로그, 티스토리, 브런치만 가능해요.",
         }
     except Exception as e:
+        # 여기 오는 건 **우리가 예상하지 못한 실패**다. 유저 탓인 경우(비지원 플랫폼,
+        # 미등록 블로그)는 위에서 이미 갈라져 나갔다.
+        #
+        # 이 catch-all 이 조용했던 탓에 네이버가 마크업을 바꿔 파서가 깨져도 우리는 알 수
+        # 없었고, 유저에게는 "다른 글로 시도해주세요"라고 유저 탓처럼 안내됐다.
+        # 모르는 실패는 일단 알린다 — 시끄러우면 그때 유형별로 내리면 된다.
+        # (특정 예외가 유저 탓 소음으로 판명되면 위에 별도 except 로 분리할 것)
         print("extract_all 에러:", e)
         traceback.print_exc()
+        alert(
+            "extract_all",
+            f"예상치 못한 추출 실패: {e}",
+            error_type=type(e).__name__,
+            blog_host=_safe_host(req.blog_url),
+        )
         return {
             "status": "error",
             "error_code": "crawl_failed",
@@ -397,7 +424,20 @@ def generate_video(req: GenerateVideoRequest, user=Depends(require_active_subscr
             "error_type": "tts_failed",
         }
     except Exception as e:
+        # TypecastError 는 위에서 갈라져 나갔다. 여기 오는 건 전부 예상 밖이다 —
+        # Creatomate 응답 파싱, S3 업로드, 자막 설정 조회 등 어디서든 터질 수 있고,
+        # 지금까지는 그 어떤 것도 알림 없이 사라졌다.
         print("[generate_video 에러]", e)
+        traceback.print_exc()
+        # scene_count 는 try 블록 첫 줄에서 할당되므로 그 줄이 터지면 미정의다.
+        # 알림 코드가 NameError 로 2차 사고를 내면 알림 자체를 잃는다 — 항상 존재하는
+        # 요청 값을 쓴다.
+        alert(
+            "generate_video",
+            f"예상치 못한 영상 생성 실패: {e}",
+            error_type=type(e).__name__,
+            requested_scene_count=getattr(req, "scene_count", None),
+        )
         return {"status": "error", "message": str(e)}
 
 @router.get("/poll-video")

--- a/auto_video_create_server/services/alerting.py
+++ b/auto_video_create_server/services/alerting.py
@@ -1,0 +1,61 @@
+"""장애 알림 마커 — CloudWatch 메트릭 필터가 잡는 단일 진입점 (2026-08-08).
+
+## 왜 별도 마커가 필요한가
+
+기존 로그의 에러 표기가 `[!]`, `[모듈명] 실패`, 예외 트레이스백으로 제각각이었고,
+특히 `[!]` 가 **진짜 장애**(Creatomate 호출 실패)와 **정상 비즈니스 결과**(크레딧 부족)를
+동시에 표시하고 있었다. 그대로 메트릭 필터를 걸면 오탐이 쏟아지고, 오탐이 쏟아지면
+사람이 알림을 무시하게 되어 모니터링이 무력해진다.
+
+그래서 **사람이 개입해야 하는 사건에만** `[ALERT]` 를 붙인다.
+
+## 붙이는 기준
+
+붙인다 (사람이 개입해야 함):
+    - 외부 API 실패 — Typecast / Creatomate / LLM 이 죽거나 인증이 깨진 경우
+    - 설정 오류 — API 키 미설정, 템플릿 ID 가 실물과 불일치
+    - 데이터 정합성 파손 — 크레딧 차감 실패 등 돈과 직결되는 쓰기 실패
+
+안 붙인다 (정상 동작이며 유저가 해결할 수 있음):
+    - 크레딧 부족
+    - 스크립트가 비어 있음
+    - 등록되지 않은 블로그 URL
+
+## 사용
+
+    from .alerting import alert
+    alert("creatomate", f"렌더 요청 실패 status={status}", template_id=template_id)
+
+CloudWatch 메트릭 필터 패턴은 `"[ALERT]"` 단순 문자열 매칭이므로,
+이 접두사를 바꾸면 알람이 조용히 죽는다. 바꿀 때는 메트릭 필터도 같이 고칠 것.
+"""
+import os
+
+ALERT_PREFIX = "[ALERT]"
+
+# 시크릿이 컨텍스트로 흘러들어가 로그에 남는 사고를 막는다.
+# 키 이름에 아래 조각이 들어가면 값을 마스킹한다.
+_SECRET_HINTS = ("key", "token", "secret", "password", "authorization", "credential")
+
+
+def _mask(key: str, value) -> str:
+    if any(hint in key.lower() for hint in _SECRET_HINTS):
+        return "***"
+    return str(value)
+
+
+def alert(source: str, message: str, **context) -> str:
+    """장애를 CloudWatch 에 기록한다. 기록한 문자열을 반환(테스트용).
+
+    Args:
+        source: 장애가 난 외부 시스템/모듈 (예: "creatomate", "typecast", "config")
+        message: 사람이 읽을 요약. 시크릿을 담지 말 것.
+        **context: 추가 진단 정보. 키 이름이 시크릿처럼 보이면 값이 마스킹된다.
+    """
+    env = os.environ.get("ENV", "unknown")
+    parts = [ALERT_PREFIX, f"env={env}", f"source={source}", message]
+    for key, value in context.items():
+        parts.append(f"{key}={_mask(key, value)}")
+    line = " ".join(str(p) for p in parts if p)
+    print(line)
+    return line

--- a/auto_video_create_server/services/create_creatomate_video.py
+++ b/auto_video_create_server/services/create_creatomate_video.py
@@ -4,6 +4,7 @@ import json
 import time
 from dotenv import load_dotenv
 from .account_service import check_user_credits, deduct_credits, get_current_credits
+from .alerting import alert
 from .scene_counts import get_template_id, normalize_scene_count
 
 load_dotenv()
@@ -24,7 +25,7 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
     template_id = get_template_id(scene_count)
     if not template_id:
         # 해당 장면 수의 Creatomate 템플릿이 아직 등록되지 않음 — 크래시 대신 안전한 에러 응답
-        print(f"[create_creatomate_video] scene_count={scene_count} 템플릿 미등록")
+        alert("config", "장면 수 템플릿 미등록", scene_count=scene_count)
         return {
             "error": "scene_count_template_not_configured",
             "message": f"{scene_count}장면 템플릿이 아직 준비되지 않았어요. 다른 장면 수로 시도해주세요.",
@@ -93,7 +94,15 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
                 )
             if not detail:
                 detail = (response.text or "")[:200]
-            print(f"[create_creatomate_video] 실패 status={response.status_code} detail={detail}")
+            # 설정 불일치(존재하지 않는 템플릿 ID)와 API 장애를 구분해 알린다.
+            # 2026-08-08: test 5장면 템플릿이 Creatomate 에서 삭제됐는데 나흘간 아무도 몰랐다.
+            source = "config" if response.status_code == 400 else "creatomate"
+            alert(
+                source,
+                f"렌더 요청 실패 status={response.status_code} detail={detail}",
+                template_id=template_id,
+                scene_count=scene_count,
+            )
             return {
                 "error": "creatomate_error",
                 "message": f"Creatomate {response.status_code}: {detail}".strip(),
@@ -108,19 +117,21 @@ def create_creatomate_video(audio_paths, scripts, title=None, output_path="creat
                 if deduct_success:
                     print(f"[+] {user_id} 크레딧 차감 완료 (render_id: {render_id})")
                 else:
-                    print(f"[!] {user_id} 크레딧 차감 실패")
+                    # 렌더는 시작됐는데 차감이 안 된 상태 — 돈이 새므로 반드시 알린다.
+                    alert("credits", "렌더 시작 후 크레딧 차감 실패", user_id=user_id, render_id=render_id)
             elif isinstance(result, dict) and result.get('id'):
                 render_id = result['id']
                 deduct_success = deduct_credits(user_id, 1000, "video_generation")
                 if deduct_success:
                     print(f"[+] {user_id} 크레딧 차감 완료 (render_id: {render_id})")
                 else:
-                    print(f"[!] {user_id} 크레딧 차감 실패")
+                    # 렌더는 시작됐는데 차감이 안 된 상태 — 돈이 새므로 반드시 알린다.
+                    alert("credits", "렌더 시작 후 크레딧 차감 실패", user_id=user_id, render_id=render_id)
         
         return result
         
     except Exception as e:
-        print(f"[!] Creatomate API 호출 실패: {e}")
+        alert("creatomate", f"API 호출 예외: {e}", template_id=template_id)
         return {
             "error": "api_error",
             "message": f"영상 생성 API 호출 실패: {str(e)}"

--- a/auto_video_create_server/services/tts_typecast.py
+++ b/auto_video_create_server/services/tts_typecast.py
@@ -16,6 +16,8 @@ import time
 import boto3
 import requests
 
+from .alerting import alert
+
 TYPECAST_URL = "https://api.typecast.ai/v1/text-to-speech"
 DEFAULT_MODEL = "ssfm-v30"
 DEFAULT_VOICE_ID = "tc_62e8f21e979b3860fe2f6a24"
@@ -56,6 +58,7 @@ def tts_with_typecast(text, output_path, api_key, voice_id=None, speed=1.4,
                       model=DEFAULT_MODEL, language="kor"):
     """텍스트 1건 → mp3 파일. 성공 시 (output_path, None) 반환."""
     if not api_key:
+        alert("config", "TYPECAST_API_KEY 미설정")
         raise TypecastError("TYPECAST_API_KEY 가 설정되지 않았습니다.")
 
     text = (text or "").strip()
@@ -89,6 +92,7 @@ def tts_with_typecast(text, output_path, api_key, voice_id=None, speed=1.4,
             if attempt == 0:
                 time.sleep(RETRY_BACKOFF_SEC)
                 continue
+            alert("typecast", f"재시도 후에도 요청 실패: {e}")
             raise TypecastError(last_error)
 
         if response.status_code == 200:
@@ -109,8 +113,15 @@ def tts_with_typecast(text, output_path, api_key, voice_id=None, speed=1.4,
         if response.status_code in RETRY_STATUSES and attempt == 0:
             time.sleep(RETRY_BACKOFF_SEC)
             continue
+
+        # 401/402/403 은 키가 틀렸거나 플랜/결제 문제 — 재시도로는 절대 안 풀리고
+        # 사람이 Typecast 콘솔에 들어가야 한다. 그래서 API 장애와 분리해서 알린다.
+        # (2026-08-05~08 에 이 세 코드로 이틀을 날렸다.)
+        source = "config" if response.status_code in (401, 402, 403) else "typecast"
+        alert(source, last_error)
         raise TypecastError(last_error)
 
+    alert("typecast", last_error or "Typecast 호출 실패")
     raise TypecastError(last_error or "Typecast 호출 실패")
 
 

--- a/auto_video_create_server/tests/test_alerting.py
+++ b/auto_video_create_server/tests/test_alerting.py
@@ -1,0 +1,165 @@
+"""장애 알림 마커([ALERT]) — 단위 테스트 (실제 API 호출 없음).
+
+이 테스트가 지키는 것은 두 가지다.
+
+1. 진짜 장애에는 반드시 마커가 붙는다  → 알람이 안 울리는 사고를 막는다
+2. 정상 비즈니스 결과에는 절대 안 붙는다 → 오탐으로 알림이 무시되는 사고를 막는다
+
+2번이 특히 중요하다. 오탐이 반복되면 사람이 알림을 안 보게 되고,
+그러면 모니터링이 있으나 마나가 된다.
+"""
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services import tts_typecast as tc  # noqa: E402
+from services.alerting import ALERT_PREFIX, alert  # noqa: E402
+
+
+def _capture(fn):
+    """fn 을 실행하고 stdout 을 문자열로 돌려준다 (예외는 삼킨다)."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        try:
+            fn()
+        except Exception:
+            pass
+    return buf.getvalue()
+
+
+def _resp(status=200, content=b"\xff\xfbMP3", body=None):
+    r = mock.Mock()
+    r.status_code = status
+    r.content = content
+    r.json.return_value = body if body is not None else {}
+    r.text = ""
+    return r
+
+
+class TestAlertFormat(unittest.TestCase):
+    def test_prefix_present(self):
+        line = alert("creatomate", "무언가 실패")
+        self.assertTrue(line.startswith(ALERT_PREFIX))
+
+    def test_metric_filter_pattern_matches(self):
+        """CloudWatch 메트릭 필터는 "[ALERT]" 부분 문자열로 매칭한다.
+
+        접두사를 바꾸면 알람이 조용히 죽으므로 여기서 고정한다.
+        """
+        self.assertEqual(ALERT_PREFIX, "[ALERT]")
+        self.assertIn("[ALERT]", alert("x", "y"))
+
+    def test_source_and_env_included(self):
+        with mock.patch.dict(os.environ, {"ENV": "production"}):
+            line = alert("typecast", "실패")
+        self.assertIn("source=typecast", line)
+        self.assertIn("env=production", line)
+
+    def test_context_rendered(self):
+        line = alert("config", "미등록", scene_count=5, template_id="abc")
+        self.assertIn("scene_count=5", line)
+        self.assertIn("template_id=abc", line)
+
+    def test_secrets_masked(self):
+        line = alert("config", "실패", api_key="sk-real-secret",
+                     authorization="Bearer xyz", user_id="linkplc")
+        self.assertNotIn("sk-real-secret", line)
+        self.assertNotIn("xyz", line)
+        self.assertIn("api_key=***", line)
+        # 시크릿이 아닌 값은 그대로 보여야 진단이 된다
+        self.assertIn("user_id=linkplc", line)
+
+    def test_printed_to_stdout(self):
+        out = _capture(lambda: alert("creatomate", "렌더 실패"))
+        self.assertIn("[ALERT]", out)
+
+
+class TestTypecastAlerts(unittest.TestCase):
+    """외부 API 실패 → 알림이 울려야 한다."""
+
+    def test_missing_api_key_alerts_as_config(self):
+        out = _capture(lambda: tc.tts_with_typecast("안녕", "/tmp/a.mp3", ""))
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=config", out)
+
+    def test_auth_failure_alerts_as_config(self):
+        """401/402/403 은 재시도로 안 풀린다 — 사람이 콘솔에 가야 한다."""
+        for status in (401, 402, 403):
+            with mock.patch.object(tc.requests, "post", return_value=_resp(status=status)):
+                out = _capture(lambda: tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY"))
+            self.assertIn("[ALERT]", out, f"status={status} 알림 없음")
+            self.assertIn("source=config", out, f"status={status} 분류 오류")
+
+    def test_server_error_alerts_as_typecast(self):
+        with mock.patch.object(tc.requests, "post", return_value=_resp(status=500)), \
+             mock.patch.object(tc.time, "sleep"):
+            out = _capture(lambda: tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY"))
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=typecast", out)
+
+    def test_api_key_never_appears_in_alert(self):
+        with mock.patch.object(tc.requests, "post", return_value=_resp(status=401)):
+            out = _capture(lambda: tc.tts_with_typecast("안녕", "/tmp/a.mp3", "SUPER-SECRET-KEY"))
+        self.assertNotIn("SUPER-SECRET-KEY", out)
+
+    def test_success_does_not_alert(self):
+        with mock.patch.object(tc.requests, "post", return_value=_resp()), \
+             mock.patch("builtins.open", mock.mock_open()):
+            out = _capture(lambda: tc.tts_with_typecast("안녕", "/tmp/a.mp3", "KEY"))
+        self.assertNotIn("[ALERT]", out)
+
+
+class TestNoFalseAlarms(unittest.TestCase):
+    """정상 비즈니스 결과 → 알림이 울리면 안 된다.
+
+    기존 `[!]` 마커는 진짜 장애와 정상 상황을 섞어서 표시하고 있었다.
+    그 구분이 [ALERT] 도입의 핵심 이유이므로 회귀를 여기서 막는다.
+    """
+
+    def test_empty_script_does_not_alert(self):
+        """빈 스크립트는 유저가 채우면 되는 문제 — 사람이 새벽에 깰 일이 아니다."""
+        out = _capture(lambda: tc.tts_with_typecast("", "/tmp/a.mp3", "KEY"))
+        self.assertNotIn("[ALERT]", out)
+
+    def test_insufficient_credits_does_not_alert(self):
+        from services import create_creatomate_video as ccv
+
+        with mock.patch.object(ccv, "check_user_credits", return_value=False), \
+             mock.patch.object(ccv, "get_current_credits", return_value=0):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                result = ccv.create_creatomate_video([], [], user_id="someone")
+        self.assertEqual(result["error"], "insufficient_credits")
+        self.assertNotIn("[ALERT]", buf.getvalue())
+
+
+class TestCreatomateAlerts(unittest.TestCase):
+    def _run(self, status, body):
+        from services import create_creatomate_video as ccv
+
+        with mock.patch.object(ccv.requests, "post", return_value=_resp(status=status, body=body)):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                ccv.create_creatomate_video(["a.mp3"], ["s"], scene_count=5)
+        return buf.getvalue()
+
+    def test_missing_template_alerts_as_config(self):
+        """2026-08-08 회귀 방지: test 5장면 템플릿이 삭제됐는데 나흘간 아무도 몰랐다."""
+        out = self._run(400, {"hint": "No template was found with that ID."})
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=config", out)
+        self.assertIn("template_id=", out)
+
+    def test_server_error_alerts_as_creatomate(self):
+        out = self._run(503, {"message": "service unavailable"})
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=creatomate", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/auto_video_create_server/tests/test_endpoint_alerts.py
+++ b/auto_video_create_server/tests/test_endpoint_alerts.py
@@ -1,0 +1,154 @@
+"""메인 엔드포인트 catch-all 알림 — 단위 테스트 (2026-08-09).
+
+## 이 테스트가 막는 것
+
+`extract_all` / `generate_video` 의 마지막 `except Exception` 이 조용했다.
+Typecast·Creatomate 외의 모든 실패(크롤러 파싱 깨짐, LLM 응답 이상, S3 실패 등)가
+전부 여기로 흘러와 HTTP 200 으로 나갔다. 그래서:
+
+  - `[ALERT]` 메트릭 필터: 마커가 없어 안 잡힘
+  - Lambda Errors 알람: Lambda 는 성공으로 끝나므로 안 잡힘
+  - API Gateway 5xx: 200 응답이라 안 잡힘
+
+즉 **완전한 사각지대**였다. 게다가 유저에게는 "다른 글로 시도해주세요"라고
+유저 탓처럼 안내됐다.
+
+## 두 방향 모두 고정한다
+
+1. 예상 밖 실패 → 반드시 알림 (사각지대 재발 방지)
+2. 유저 탓 실패 → 절대 알림 없음 (오탐으로 알림이 무시되는 것 방지)
+"""
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("CREATOMATE_API_KEY", "dummy")
+
+import api.blog as blog  # noqa: E402
+from crawler.dispatcher import UnsupportedPlatformError  # noqa: E402
+
+
+USER = {"id": "tester"}
+
+
+def _capture(fn):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        try:
+            result = fn()
+        except Exception as e:
+            result = e
+    return result, buf.getvalue()
+
+
+class TestExtractAllAlerts(unittest.TestCase):
+    def _req(self, url="https://blog.naver.com/someone/123"):
+        return blog.ExtractMediaRequest(blog_url=url, scene_count=5)
+
+    def test_unexpected_failure_alerts(self):
+        """파서가 깨진 경우 — 반드시 알려야 한다."""
+        with mock.patch.object(blog, "validate_blog_url", return_value=True), \
+             mock.patch.object(
+                 blog, "get_blog_media_and_scripts",
+                 side_effect=ValueError("본문 영역을 찾을 수 없습니다.")):
+            result, out = _capture(lambda: blog.extract_all(self._req(), user=USER))
+
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=extract_all", out)
+        self.assertIn("error_type=ValueError", out)
+        # 유저에게는 기존 메시지가 그대로 나가야 한다 (동작 변경 없음)
+        self.assertEqual(result["error_code"], "crawl_failed")
+
+    def test_alert_carries_host_not_full_url(self):
+        """진단에 필요한 건 어느 플랫폼인지 뿐 — 글 주소 전체는 남기지 않는다."""
+        url = "https://blog.naver.com/someone/verysecretpost123"
+        with mock.patch.object(blog, "validate_blog_url", return_value=True), \
+             mock.patch.object(blog, "get_blog_media_and_scripts",
+                               side_effect=RuntimeError("boom")):
+            _, out = _capture(lambda: blog.extract_all(self._req(url), user=USER))
+
+        self.assertIn("blog_host=blog.naver.com", out)
+        self.assertNotIn("verysecretpost123", out)
+
+    def test_unsupported_platform_does_not_alert(self):
+        """유저가 지원 안 하는 플랫폼을 넣은 것 — 우리가 할 일이 없다."""
+        with mock.patch.object(blog, "validate_blog_url", return_value=True), \
+             mock.patch.object(blog, "get_blog_media_and_scripts",
+                               side_effect=UnsupportedPlatformError("velog.io")):
+            result, out = _capture(lambda: blog.extract_all(self._req(), user=USER))
+
+        self.assertNotIn("[ALERT]", out)
+        self.assertEqual(result["error_code"], "unsupported_platform")
+
+    def test_unregistered_blog_does_not_alert(self):
+        """등록 안 된 블로그 — 정상적인 거절이다."""
+        with mock.patch.object(blog, "validate_blog_url", return_value=False):
+            result, out = _capture(lambda: blog.extract_all(self._req(), user=USER))
+
+        self.assertNotIn("[ALERT]", out)
+        self.assertEqual(result["error_code"], "blog_not_registered")
+
+    def test_success_does_not_alert(self):
+        with mock.patch.object(blog, "validate_blog_url", return_value=True), \
+             mock.patch.object(blog, "get_blog_media_and_scripts",
+                               return_value={"images": [], "scripts": []}):
+            result, out = _capture(lambda: blog.extract_all(self._req(), user=USER))
+
+        self.assertNotIn("[ALERT]", out)
+        self.assertEqual(result["status"], "success")
+
+
+class TestGenerateVideoAlerts(unittest.TestCase):
+    def _req(self):
+        return blog.GenerateVideoRequest(
+            title="테스트",
+            scripts=["안녕하세요"],
+            sections=[
+                blog.SectionMedia(type="image", url="https://example.com/a.jpg")
+            ],
+            scene_count=5,
+        )
+
+    def test_unexpected_failure_alerts(self):
+        with mock.patch.object(
+            blog, "normalize_scene_count", side_effect=RuntimeError("boom")
+        ):
+            result, out = _capture(lambda: blog.generate_video(self._req(), user=USER))
+
+        self.assertIn("[ALERT]", out)
+        self.assertIn("source=generate_video", out)
+        self.assertIn("error_type=RuntimeError", out)
+        self.assertEqual(result["status"], "error")
+
+    def test_alert_survives_failure_on_first_line(self):
+        """scene_count 할당 줄에서 터져도 알림 코드가 NameError 를 내면 안 된다.
+
+        알림 코드가 2차 사고를 내면 알림 자체를 잃는다.
+        """
+        with mock.patch.object(
+            blog, "normalize_scene_count", side_effect=RuntimeError("boom")
+        ):
+            result, out = _capture(lambda: blog.generate_video(self._req(), user=USER))
+
+        self.assertNotIsInstance(result, Exception, "except 블록이 예외를 냈다")
+        self.assertIn("requested_scene_count=5", out)
+
+    def test_tts_failure_does_not_double_alert(self):
+        """TypecastError 는 tts_typecast 안에서 이미 알린다 — 여기서 또 알리면 중복이다."""
+        with mock.patch.object(blog, "normalize_scene_count", return_value=5), \
+             mock.patch.object(
+                 blog, "tts_with_typecast_multi",
+                 side_effect=blog.TypecastError("Typecast 401: invalid")):
+            result, out = _capture(lambda: blog.generate_video(self._req(), user=USER))
+
+        self.assertEqual(result["error_code"], "tts_failed")
+        self.assertNotIn("source=generate_video", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 왜

유료 유저가 생겨 장애를 **유저 제보 전에** 감지해야 한다. 어제 CloudWatch 알람 4종을 붙였고(SNS→이메일 전달까지 검증 완료), 이 PR 은 그 알람이 잡을 **로그 마커**를 심는다.

지금까지 겪은 장애는 전부 유저 제보로 발견됐다 — Supertone 종료, Typecast 키 오류, Creatomate 템플릿 삭제(나흘). 전부 외부 의존성 실패이거나 설정 불일치였다.

## 무엇을

- `services/alerting.py` — `alert(source, message, **context)` 단일 진입점. `env`/`source`/컨텍스트를 함께 남기고, 키 이름이 시크릿처럼 보이면 값을 마스킹한다.
- `create_creatomate_video` — 템플릿 미등록 / 렌더 실패 / 호출 예외 / 렌더 후 크레딧 차감 실패에 적용.
- `tts_typecast` — 키 미설정, 재시도 후 실패, 상태 코드별 분류.

**설정 오류와 API 장애를 분리**했다. Creatomate 400 과 Typecast 401/402/403 은 재시도로 절대 안 풀리고 사람이 콘솔에 들어가야 하므로 `source=config`, 나머지는 `source=creatomate` / `source=typecast`.

## 오탐 방지가 핵심

기존 `[!]` 는 진짜 장애(Creatomate 호출 실패)와 정상 상황(크레딧 부족)을 **동시에** 표시하고 있었다. 그대로 필터를 걸면 오탐이 쏟아지고, 오탐이 쌓이면 사람이 알림을 무시하게 되어 모니터링이 있으나 마나가 된다.

그래서 크레딧 부족·빈 스크립트 같은 정상 결과에는 붙이지 않으며, 이를 테스트로 고정했다.

## 검증

- 신규 테스트 15개 (`tests/test_alerting.py`), 전체 158개 통과
- 메트릭 필터 패턴 `"[ALERT]"` 는 `ALERT_PREFIX` 와 짝 — 접두사를 바꾸면 알람이 **에러 없이 조용히 죽는다**. 테스트가 접두사를 고정한다.
- 실제 로그 라인으로 필터 매칭 검증 완료: 장애 3건 매칭 / 오탐 0건

## 배포

`main` 머지 시 test Lambda 자동 배포. prod 는 `prod` 브랜치로 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)