### PR TITLE
fix: test 5장면 템플릿 ID 교체 + 검증 스크립트 User-Agent

### DIFF
--- a/auto_video_create_server/scripts/verify_templates.py
+++ b/auto_video_create_server/scripts/verify_templates.py
@@ -38,12 +38,20 @@ from services.scene_counts import ALLOWED_SCENE_COUNTS, SCENE_COUNT_CONFIG  # no
 API_URL = "https://api.creatomate.com/v1/templates/{}"
 TIMEOUT = 15
 
+# Creatomate 앞단의 Cloudflare 가 urllib 기본 User-Agent(`Python-urllib/3.x`)를
+# 차단한다 — 키가 멀쩡해도 `403 error code: 1010` 이 돌아온다. 이걸 모르면
+# "키가 잘못됐나" 로 한참 헤매게 되므로 명시적으로 보낸다. (2026-08-09 확인)
+USER_AGENT = "auto-video-create/1.0 (template-verifier)"
+
 
 def fetch_template(template_id, api_key):
     """(상태, 페이로드) 반환. 상태: 'ok' | 'not_found' | 'error:...'"""
     req = urllib.request.Request(
         API_URL.format(template_id),
-        headers={"Authorization": f"Bearer {api_key}"},
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": USER_AGENT,
+        },
     )
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:

--- a/auto_video_create_server/services/scene_counts.py
+++ b/auto_video_create_server/services/scene_counts.py
@@ -41,7 +41,12 @@ SCENE_COUNT_CONFIG: dict = {
     5: {
         # 현행 운영 템플릿 (기존 동작 100% 유지)
         "template_id_prod": "8971a2e5-3875-4d2d-9983-eefe9a76b476",
-        "template_id_test": "eda9d421-b086-4660-9f3c-9236d826226f",
+        # 2026-08-09 교체: 기존 test 5장면(eda9d421)은 Creatomate 에서 삭제된 상태였다.
+        # 08-08 에 "No template was found with that ID" 400 으로 드러났고, 나흘간
+        # 아무도 몰랐다. 5는 기본 장면 수라 test 에서 기본 설정으로 만들면 무조건
+        # 실패하는 상태였다. 새로 만든 템플릿의 ID 로 교체한다.
+        # (scripts/verify_templates.py 가 이런 불일치를 유저보다 먼저 잡는다)
+        "template_id_test": "4a8a79ee-6b4e-427d-bba7-2b1208124c9a",
         "subtitle_suffixes": ["6K5", "JTM", "MDV", "5Z2", "D6M"],
     },
     6: {


### PR DESCRIPTION
## 검증 스크립트가 잡아낸 실제 불일치

머지된 `scripts/verify_templates.py` 로 10개 템플릿을 실물 조회했더니 **test 5장면만 없었다.**

```
test  5  eda9d421-b086-4660-9f3c-9236d826226f   없음
```

코드의 ID 는 2026-08-08 에 Creatomate 에서 삭제된 것이었다. 그날 400 "No template was found with that ID" 로 드러났지만 **나흘간 아무도 몰랐고**, 5는 **기본 장면 수**라 test 에서 기본 설정으로 만들면 무조건 실패하는 상태였다.

Creatomate 계정을 조회해보니 `test_5_slot` 이 **새 ID** 로 존재했다 (오늘 08:01 생성). Creatomate 는 ID 를 지정해 만들 수 없어서, 재생성하면 반드시 새 ID 가 발급된다.

| | 이전 | 이후 |
|---|---|---|
| test 5장면 | `eda9d421-…` (삭제됨) | `4a8a79ee-6b4e-427d-bba7-2b1208124c9a` |

## User-Agent 도 함께 고쳤다

Creatomate 앞단의 Cloudflare 가 urllib 기본 User-Agent(`Python-urllib/3.x`)를 차단한다 — 키가 멀쩡해도 `403 error code: 1010` 이 온다.

이대로였다면 검증 스크립트가 **항상 실패하면서 "키가 잘못됐다"고 알려** 엉뚱한 곳을 뒤지게 만들었을 것이다. 우리가 이번 사이클 내내 없애려던 바로 그 종류의, 오해를 부르는 에러다.

## 검증

수정 후 10개 전부 통과.

```
10개 템플릿 전부 정상 — 존재 + 엔딩 페이드 적용 확인됨
```

전체 테스트 166개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)